### PR TITLE
✨ feat: MenuItem/ContextMenu実行 + Asset作成 + Component追加削除

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,6 +151,58 @@ unity-cli gameobject modify --name "MyCube" --position 5,0,0 --rotation 0,45,0
 unity-cli gameobject delete --name "MyCube"
 ```
 
+### コンポーネント操作
+
+```bash
+# コンポーネント一覧
+unity-cli component list -t "Main Camera"
+
+# コンポーネント詳細
+unity-cli component inspect -t "Main Camera" -T Camera
+
+# コンポーネント追加
+unity-cli component add -t "Player" -T Rigidbody
+
+# コンポーネント削除
+unity-cli component remove -t "Player" -T Rigidbody
+```
+
+### メニュー/ContextMenu
+
+```bash
+# メニュー実行
+unity-cli menu exec "Edit/Play"
+unity-cli menu exec "Assets/Refresh"
+unity-cli menu exec "Window/General/Console"
+
+# メニュー一覧
+unity-cli menu list                    # 全メニュー
+unity-cli menu list -f "Assets"        # フィルタリング
+unity-cli menu list -f "Play" -l 20    # 件数制限
+
+# ContextMenu実行（シーン内オブジェクト）
+unity-cli menu context "Reset" -t "/Player"
+
+# ContextMenu実行（ScriptableObject）
+unity-cli menu context "DoSomething" -t "Assets/Data/Config.asset"
+
+# ContextMenu実行（Prefab）
+unity-cli menu context "Initialize" -t "Assets/Prefabs/Enemy.prefab"
+```
+
+### アセット操作
+
+```bash
+# Prefab作成
+unity-cli asset prefab -s "Player" -p "Assets/Prefabs/Player.prefab"
+
+# ScriptableObject作成
+unity-cli asset scriptable-object -T "GameConfig" -p "Assets/Data/Config.asset"
+
+# アセット情報
+unity-cli asset info "Assets/Data/Config.asset"
+```
+
 ### マテリアル操作
 
 ```bash
@@ -186,6 +238,22 @@ for page in client.scene.iterate_hierarchy(page_size=100):
 result = client.tests.run("edit", filter_options=TestFilterOptions(
     category_names=["Unit"]
 ))
+
+# メニュー実行
+client.menu.execute("Edit/Play")
+client.menu.list(filter_text="Assets", limit=50)
+
+# ContextMenu実行
+client.menu.context("DoSomething", target="/Player")
+client.menu.context("LogInfo", target="Assets/Data/Config.asset")
+
+# コンポーネント操作
+client.component.add("Rigidbody", target="Player")
+client.component.remove("Rigidbody", target="Player")
+
+# アセット作成
+client.asset.create_prefab("Assets/Prefabs/Player.prefab", source="Player")
+client.asset.create_scriptable_object("GameConfig", "Assets/Data/Config.asset")
 ```
 
 ## オプション

--- a/UnityBridge/Editor/IsExternalInit.cs
+++ b/UnityBridge/Editor/IsExternalInit.cs
@@ -1,0 +1,8 @@
+// Polyfill for C# 9 record types in Unity (requires .NET Standard 2.1 or .NET 5+)
+// This enables 'record' and 'init' keywords in older runtimes.
+
+// ReSharper disable once CheckNamespace
+namespace System.Runtime.CompilerServices
+{
+    internal static class IsExternalInit { }
+}

--- a/UnityBridge/Editor/IsExternalInit.cs.meta
+++ b/UnityBridge/Editor/IsExternalInit.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 6515633256f8545c1b108b2c759dfec3

--- a/UnityBridge/Editor/Tools/Asset.cs
+++ b/UnityBridge/Editor/Tools/Asset.cs
@@ -1,0 +1,230 @@
+using System;
+using System.Linq;
+using Newtonsoft.Json.Linq;
+using UnityEditor;
+using UnityEngine;
+
+namespace UnityBridge.Tools
+{
+    /// <summary>
+    /// Handler for asset commands.
+    /// Creates and manages Unity assets (Prefabs, ScriptableObjects, etc.)
+    /// </summary>
+    [BridgeTool("asset")]
+    public static class Asset
+    {
+        public static JObject HandleCommand(JObject parameters)
+        {
+            var action = parameters["action"]?.Value<string>() ?? "";
+
+            return action.ToLowerInvariant() switch
+            {
+                "create_prefab" => CreatePrefab(parameters),
+                "create_scriptable_object" => CreateScriptableObject(parameters),
+                "info" => GetAssetInfo(parameters),
+                _ => throw new ProtocolException(
+                    ErrorCode.InvalidParams,
+                    $"Unknown action: {action}. Valid: create_prefab, create_scriptable_object, info")
+            };
+        }
+
+        private static JObject CreatePrefab(JObject parameters)
+        {
+            var sourceName = parameters["source"]?.Value<string>();
+            var sourceId = parameters["sourceId"]?.Value<int>();
+            var path = parameters["path"]?.Value<string>();
+
+            if (string.IsNullOrEmpty(sourceName) && sourceId == null)
+            {
+                throw new ProtocolException(
+                    ErrorCode.InvalidParams,
+                    "Either 'source' (name) or 'sourceId' (instanceID) is required");
+            }
+
+            if (string.IsNullOrEmpty(path))
+            {
+                throw new ProtocolException(
+                    ErrorCode.InvalidParams,
+                    "'path' is required (e.g., 'Assets/Prefabs/MyPrefab.prefab')");
+            }
+
+            if (!path.EndsWith(".prefab"))
+            {
+                path += ".prefab";
+            }
+
+            GameObject source = FindGameObject(sourceName, sourceId);
+            if (source == null)
+            {
+                throw new ProtocolException(
+                    ErrorCode.InvalidParams,
+                    $"Source GameObject not found: {sourceName ?? sourceId?.ToString()}");
+            }
+
+            // Ensure directory exists
+            var directory = System.IO.Path.GetDirectoryName(path);
+            if (!string.IsNullOrEmpty(directory) && !AssetDatabase.IsValidFolder(directory))
+            {
+                CreateFolderRecursively(directory);
+            }
+
+            var prefab = PrefabUtility.SaveAsPrefabAsset(source, path);
+            if (prefab == null)
+            {
+                throw new ProtocolException(
+                    ErrorCode.InternalError,
+                    $"Failed to create prefab at: {path}");
+            }
+
+            return new JObject
+            {
+                ["message"] = $"Prefab created: {path}",
+                ["path"] = path,
+                ["assetGuid"] = AssetDatabase.AssetPathToGUID(path)
+            };
+        }
+
+        private static JObject CreateScriptableObject(JObject parameters)
+        {
+            var typeName = parameters["type"]?.Value<string>();
+            var path = parameters["path"]?.Value<string>();
+
+            if (string.IsNullOrEmpty(typeName))
+            {
+                throw new ProtocolException(
+                    ErrorCode.InvalidParams,
+                    "'type' is required (ScriptableObject type name)");
+            }
+
+            if (string.IsNullOrEmpty(path))
+            {
+                throw new ProtocolException(
+                    ErrorCode.InvalidParams,
+                    "'path' is required (e.g., 'Assets/Data/MyData.asset')");
+            }
+
+            if (!path.EndsWith(".asset"))
+            {
+                path += ".asset";
+            }
+
+            var type = FindType(typeName);
+            if (type == null)
+            {
+                throw new ProtocolException(
+                    ErrorCode.InvalidParams,
+                    $"Type not found: {typeName}");
+            }
+
+            if (!typeof(ScriptableObject).IsAssignableFrom(type))
+            {
+                throw new ProtocolException(
+                    ErrorCode.InvalidParams,
+                    $"Type '{typeName}' is not a ScriptableObject");
+            }
+
+            // Ensure directory exists
+            var directory = System.IO.Path.GetDirectoryName(path);
+            if (!string.IsNullOrEmpty(directory) && !AssetDatabase.IsValidFolder(directory))
+            {
+                CreateFolderRecursively(directory);
+            }
+
+            var asset = ScriptableObject.CreateInstance(type);
+            AssetDatabase.CreateAsset(asset, path);
+            AssetDatabase.SaveAssets();
+
+            return new JObject
+            {
+                ["message"] = $"ScriptableObject created: {path}",
+                ["path"] = path,
+                ["type"] = type.FullName,
+                ["assetGuid"] = AssetDatabase.AssetPathToGUID(path)
+            };
+        }
+
+        private static JObject GetAssetInfo(JObject parameters)
+        {
+            var path = parameters["path"]?.Value<string>();
+
+            if (string.IsNullOrEmpty(path))
+            {
+                throw new ProtocolException(
+                    ErrorCode.InvalidParams,
+                    "'path' is required");
+            }
+
+            var asset = AssetDatabase.LoadMainAssetAtPath(path);
+            if (asset == null)
+            {
+                throw new ProtocolException(
+                    ErrorCode.InvalidParams,
+                    $"Asset not found: {path}");
+            }
+
+            return new JObject
+            {
+                ["path"] = path,
+                ["name"] = asset.name,
+                ["type"] = asset.GetType().FullName,
+                ["instanceID"] = asset.GetInstanceID(),
+                ["guid"] = AssetDatabase.AssetPathToGUID(path)
+            };
+        }
+
+        private static GameObject FindGameObject(string name, int? instanceId)
+        {
+            if (instanceId.HasValue)
+            {
+                var obj = EditorUtility.InstanceIDToObject(instanceId.Value);
+                if (obj is GameObject go)
+                    return go;
+                return null;
+            }
+
+            if (!string.IsNullOrEmpty(name))
+            {
+                return GameObject.Find(name) ?? GameObject.Find("/" + name);
+            }
+
+            return null;
+        }
+
+        private static Type FindType(string typeName)
+        {
+            foreach (var assembly in AppDomain.CurrentDomain.GetAssemblies())
+            {
+                try
+                {
+                    var type = assembly.GetType(typeName);
+                    if (type != null) return type;
+
+                    type = assembly.GetTypes().FirstOrDefault(t =>
+                        t.Name == typeName || t.FullName == typeName);
+                    if (type != null) return type;
+                }
+                catch
+                {
+                    // Skip assemblies that fail
+                }
+            }
+            return null;
+        }
+
+        private static void CreateFolderRecursively(string path)
+        {
+            var parts = path.Split('/');
+            var current = parts[0]; // "Assets"
+
+            for (int i = 1; i < parts.Length; i++)
+            {
+                var next = current + "/" + parts[i];
+                if (!AssetDatabase.IsValidFolder(next))
+                {
+                    AssetDatabase.CreateFolder(current, parts[i]);
+                }
+                current = next;
+            }
+        }
+    }
+}

--- a/UnityBridge/Editor/Tools/Asset.cs.meta
+++ b/UnityBridge/Editor/Tools/Asset.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 1a34f1c080b2d43ef8cd5fb110fad6fd

--- a/UnityBridge/Editor/Tools/MenuItem.cs
+++ b/UnityBridge/Editor/Tools/MenuItem.cs
@@ -1,0 +1,343 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using Newtonsoft.Json.Linq;
+using UnityEditor;
+using UnityEngine;
+
+namespace UnityBridge.Tools
+{
+    /// <summary>
+    /// Handler for menu item commands.
+    /// Executes arbitrary MenuItems and ContextMenus via reflection.
+    /// </summary>
+    [BridgeTool("menu")]
+    public static class MenuItem
+    {
+        public static JObject HandleCommand(JObject parameters)
+        {
+            var action = parameters["action"]?.ToString() ?? "execute";
+
+            return action switch
+            {
+                "execute" => ExecuteMenuItem(parameters),
+                "list" => ListMenuItems(parameters),
+                "context" => ExecuteContextMenu(parameters),
+                _ => new JObject
+                {
+                    ["error"] = $"Unknown action: {action}. Valid: execute, list, context"
+                }
+            };
+        }
+
+        private static JObject ExecuteMenuItem(JObject parameters)
+        {
+            var path = parameters["path"]?.ToString();
+            if (string.IsNullOrEmpty(path))
+            {
+                return new JObject { ["error"] = "path is required" };
+            }
+
+            var result = EditorApplication.ExecuteMenuItem(path);
+
+            return new JObject
+            {
+                ["success"] = result,
+                ["path"] = path,
+                ["message"] = result
+                    ? $"Executed: {path}"
+                    : $"Failed to execute: {path} (menu not found or validation failed)"
+            };
+        }
+
+        private static JObject ListMenuItems(JObject parameters)
+        {
+            var filter = parameters["filter"]?.ToString();
+            var limit = parameters["limit"]?.ToObject<int>() ?? 100;
+
+            var menuItems = CollectMenuItems(filter, limit);
+
+            return new JObject
+            {
+                ["count"] = menuItems.Count,
+                ["items"] = new JArray(menuItems.Select(m => new JObject
+                {
+                    ["path"] = m.Path,
+                    ["priority"] = m.Priority,
+                    ["shortcut"] = m.Shortcut,
+                    ["type"] = m.DeclaringType
+                }))
+            };
+        }
+
+        private static JObject ExecuteContextMenu(JObject parameters)
+        {
+            var methodName = parameters["method"]?.ToString();
+            var targetPath = parameters["target"]?.ToString();
+
+            if (string.IsNullOrEmpty(methodName))
+            {
+                return new JObject { ["error"] = "method is required" };
+            }
+
+            UnityEngine.Object targetObject = null;
+
+            if (!string.IsNullOrEmpty(targetPath))
+            {
+                // Try to find by hierarchy path
+                var go = GameObject.Find(targetPath);
+                if (go != null)
+                {
+                    targetObject = go;
+                }
+                else
+                {
+                    // Try asset path
+                    targetObject = AssetDatabase.LoadMainAssetAtPath(targetPath);
+                }
+
+                if (targetObject == null)
+                {
+                    return new JObject
+                    {
+                        ["error"] = $"Target not found: {targetPath}"
+                    };
+                }
+            }
+
+            var result = InvokeContextMenu(methodName, targetObject);
+            return result;
+        }
+
+        private static JObject InvokeContextMenu(string methodName, UnityEngine.Object target)
+        {
+            // Search for ContextMenu attribute in all loaded assemblies
+            var assemblies = AppDomain.CurrentDomain.GetAssemblies();
+            var candidates = new List<(MethodInfo Method, Type Type, string MenuName)>();
+
+            foreach (var assembly in assemblies)
+            {
+                try
+                {
+                    foreach (var type in assembly.GetTypes())
+                    {
+                        if (!typeof(MonoBehaviour).IsAssignableFrom(type) &&
+                            !typeof(ScriptableObject).IsAssignableFrom(type))
+                            continue;
+
+                        foreach (var method in type.GetMethods(
+                            BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic))
+                        {
+                            var attr = method.GetCustomAttribute<ContextMenu>();
+                            if (attr == null) continue;
+
+                            if (attr.menuItem == methodName ||
+                                method.Name == methodName)
+                            {
+                                candidates.Add((method, type, attr.menuItem));
+                            }
+                        }
+                    }
+                }
+                catch
+                {
+                    // Skip assemblies that fail to load types
+                }
+            }
+
+            if (candidates.Count == 0)
+            {
+                return new JObject
+                {
+                    ["error"] = $"ContextMenu not found: {methodName}"
+                };
+            }
+
+            // If target is a GameObject, search for components with matching ContextMenu
+            if (target is GameObject go)
+            {
+                foreach (var candidate in candidates)
+                {
+                    var component = go.GetComponent(candidate.Type);
+                    if (component != null)
+                    {
+                        try
+                        {
+                            candidate.Method.Invoke(component, null);
+                            return new JObject
+                            {
+                                ["success"] = true,
+                                ["method"] = candidate.Method.Name,
+                                ["menu"] = candidate.MenuName,
+                                ["target"] = go.name,
+                                ["component"] = candidate.Type.Name
+                            };
+                        }
+                        catch (Exception ex)
+                        {
+                            return new JObject
+                            {
+                                ["error"] = $"Failed to invoke: {ex.InnerException?.Message ?? ex.Message}"
+                            };
+                        }
+                    }
+                }
+
+                return new JObject
+                {
+                    ["error"] = $"ContextMenu '{methodName}' not found on any component of '{go.name}'"
+                };
+            }
+
+            // If target is a Component or ScriptableObject
+            if (target != null)
+            {
+                var targetType = target.GetType();
+                var match = candidates.FirstOrDefault(c =>
+                    c.Type.IsAssignableFrom(targetType) || targetType.IsAssignableFrom(c.Type));
+
+                if (match.Method == null)
+                {
+                    return new JObject
+                    {
+                        ["error"] = $"ContextMenu '{methodName}' not found on type {targetType.Name}"
+                    };
+                }
+
+                try
+                {
+                    match.Method.Invoke(target, null);
+                    return new JObject
+                    {
+                        ["success"] = true,
+                        ["method"] = match.Method.Name,
+                        ["menu"] = match.MenuName,
+                        ["target"] = target.name
+                    };
+                }
+                catch (Exception ex)
+                {
+                    return new JObject
+                    {
+                        ["error"] = $"Failed to invoke: {ex.InnerException?.Message ?? ex.Message}"
+                    };
+                }
+            }
+
+            // No target: try to invoke on selected objects
+            var selection = Selection.objects;
+            if (selection.Length == 0)
+            {
+                return new JObject
+                {
+                    ["error"] = "No target specified and nothing selected",
+                    ["hint"] = "Provide 'target' parameter or select an object in Unity"
+                };
+            }
+
+            var results = new JArray();
+            foreach (var obj in selection)
+            {
+                var objType = obj.GetType();
+                var match = candidates.FirstOrDefault(c =>
+                    c.Type.IsAssignableFrom(objType) || objType.IsAssignableFrom(c.Type));
+
+                if (match.Method != null)
+                {
+                    try
+                    {
+                        match.Method.Invoke(obj, null);
+                        results.Add(new JObject
+                        {
+                            ["success"] = true,
+                            ["target"] = obj.name
+                        });
+                    }
+                    catch (Exception ex)
+                    {
+                        results.Add(new JObject
+                        {
+                            ["success"] = false,
+                            ["target"] = obj.name,
+                            ["error"] = ex.InnerException?.Message ?? ex.Message
+                        });
+                    }
+                }
+            }
+
+            return new JObject
+            {
+                ["results"] = results,
+                ["processed"] = results.Count
+            };
+        }
+
+        private record MenuItemInfo(string Path, int Priority, string Shortcut, string DeclaringType);
+
+        private static List<MenuItemInfo> CollectMenuItems(string filter, int limit)
+        {
+            var items = new List<MenuItemInfo>();
+            var assemblies = AppDomain.CurrentDomain.GetAssemblies();
+
+            foreach (var assembly in assemblies)
+            {
+                try
+                {
+                    foreach (var type in assembly.GetTypes())
+                    {
+                        foreach (var method in type.GetMethods(
+                            BindingFlags.Static | BindingFlags.Public | BindingFlags.NonPublic))
+                        {
+                            var attr = method.GetCustomAttribute<UnityEditor.MenuItem>();
+                            if (attr == null) continue;
+
+                            // Skip validation methods
+                            if (attr.validate) continue;
+
+                            var path = attr.menuItem;
+
+                            // Apply filter
+                            if (!string.IsNullOrEmpty(filter) &&
+                                !path.Contains(filter, StringComparison.OrdinalIgnoreCase))
+                                continue;
+
+                            // Extract shortcut from path (e.g., "Edit/Play %P")
+                            var shortcut = "";
+                            var spaceIdx = path.LastIndexOf(' ');
+                            if (spaceIdx > 0)
+                            {
+                                var possibleShortcut = path.Substring(spaceIdx + 1);
+                                if (possibleShortcut.StartsWith("%") ||
+                                    possibleShortcut.StartsWith("#") ||
+                                    possibleShortcut.StartsWith("&") ||
+                                    possibleShortcut.StartsWith("_"))
+                                {
+                                    shortcut = possibleShortcut;
+                                    path = path.Substring(0, spaceIdx);
+                                }
+                            }
+
+                            items.Add(new MenuItemInfo(
+                                path,
+                                attr.priority,
+                                shortcut,
+                                type.FullName ?? type.Name
+                            ));
+
+                            if (items.Count >= limit) break;
+                        }
+                        if (items.Count >= limit) break;
+                    }
+                }
+                catch
+                {
+                    // Skip assemblies that fail to load
+                }
+                if (items.Count >= limit) break;
+            }
+
+            return items.OrderBy(i => i.Path).ToList();
+        }
+    }
+}

--- a/UnityBridge/Editor/Tools/MenuItem.cs.meta
+++ b/UnityBridge/Editor/Tools/MenuItem.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 416162ade714143cea1295b8b41cde95

--- a/unity_cli/api/__init__.py
+++ b/unity_cli/api/__init__.py
@@ -4,6 +4,7 @@ Re-exports all API classes for convenient imports:
     from unity_cli.api import ConsoleAPI, EditorAPI, ...
 """
 
+from unity_cli.api.asset import AssetAPI
 from unity_cli.api.component import ComponentAPI
 from unity_cli.api.console import ConsoleAPI
 from unity_cli.api.editor import EditorAPI
@@ -14,6 +15,7 @@ from unity_cli.api.scene import SceneAPI
 from unity_cli.api.tests import TestAPI
 
 __all__ = [
+    "AssetAPI",
     "ComponentAPI",
     "ConsoleAPI",
     "EditorAPI",

--- a/unity_cli/api/asset.py
+++ b/unity_cli/api/asset.py
@@ -1,0 +1,72 @@
+"""Asset API for Unity CLI."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from unity_cli.client import RelayConnection
+
+
+class AssetAPI:
+    """Asset operations for creating Prefabs and ScriptableObjects."""
+
+    def __init__(self, conn: RelayConnection) -> None:
+        self._conn = conn
+
+    def create_prefab(
+        self,
+        path: str,
+        source: str | None = None,
+        source_id: int | None = None,
+    ) -> dict[str, Any]:
+        """Create a Prefab from a GameObject.
+
+        Args:
+            path: Asset path (e.g., 'Assets/Prefabs/MyPrefab.prefab')
+            source: Source GameObject name
+            source_id: Source GameObject instance ID
+
+        Returns:
+            Dictionary with created prefab info
+        """
+        params: dict[str, Any] = {"action": "create_prefab", "path": path}
+        if source:
+            params["source"] = source
+        if source_id is not None:
+            params["sourceId"] = source_id
+        return self._conn.send_request("asset", params)
+
+    def create_scriptable_object(
+        self,
+        type_name: str,
+        path: str,
+    ) -> dict[str, Any]:
+        """Create a ScriptableObject asset.
+
+        Args:
+            type_name: ScriptableObject type name
+            path: Asset path (e.g., 'Assets/Data/MyData.asset')
+
+        Returns:
+            Dictionary with created asset info
+        """
+        return self._conn.send_request("asset", {
+            "action": "create_scriptable_object",
+            "type": type_name,
+            "path": path,
+        })
+
+    def info(self, path: str) -> dict[str, Any]:
+        """Get asset information.
+
+        Args:
+            path: Asset path
+
+        Returns:
+            Dictionary with asset info (name, type, guid, etc.)
+        """
+        return self._conn.send_request("asset", {
+            "action": "info",
+            "path": path,
+        })

--- a/unity_cli/api/component.py
+++ b/unity_cli/api/component.py
@@ -57,3 +57,49 @@ class ComponentAPI:
         if target_id is not None:
             params["targetId"] = target_id
         return self._conn.send_request("component", params)
+
+    def add(
+        self,
+        component_type: str,
+        target: str | None = None,
+        target_id: int | None = None,
+    ) -> dict[str, Any]:
+        """Add a component to a GameObject.
+
+        Args:
+            component_type: Component type name to add
+            target: Target GameObject name
+            target_id: Target GameObject instance ID
+
+        Returns:
+            Dictionary with added component info
+        """
+        params: dict[str, Any] = {"action": "add", "type": component_type}
+        if target:
+            params["target"] = target
+        if target_id is not None:
+            params["targetId"] = target_id
+        return self._conn.send_request("component", params)
+
+    def remove(
+        self,
+        component_type: str,
+        target: str | None = None,
+        target_id: int | None = None,
+    ) -> dict[str, Any]:
+        """Remove a component from a GameObject.
+
+        Args:
+            component_type: Component type name to remove
+            target: Target GameObject name
+            target_id: Target GameObject instance ID
+
+        Returns:
+            Dictionary with removal result
+        """
+        params: dict[str, Any] = {"action": "remove", "type": component_type}
+        if target:
+            params["target"] = target
+        if target_id is not None:
+            params["targetId"] = target_id
+        return self._conn.send_request("component", params)

--- a/unity_cli/api/menu.py
+++ b/unity_cli/api/menu.py
@@ -9,18 +9,62 @@ if TYPE_CHECKING:
 
 
 class MenuAPI:
-    """Menu operations."""
+    """Menu operations for executing Unity MenuItems and ContextMenus."""
 
     def __init__(self, conn: RelayConnection) -> None:
         self._conn = conn
 
-    def execute(self, menu_path: str) -> dict[str, Any]:
+    def execute(self, path: str) -> dict[str, Any]:
         """Execute Unity menu item.
 
         Args:
-            menu_path: Menu item path (e.g., "Assets/Refresh")
+            path: Menu item path (e.g., "Edit/Play", "Assets/Refresh")
 
         Returns:
-            Dictionary with operation result
+            Dictionary with:
+            - success: bool - Whether the menu item was executed
+            - path: str - The menu path
+            - message: str - Result message
         """
-        return self._conn.send_request("execute_menu_item", {"menu_path": menu_path})
+        return self._conn.send_request("menu", {"action": "execute", "path": path})
+
+    def list(
+        self,
+        filter_text: str | None = None,
+        limit: int = 100,
+    ) -> dict[str, Any]:
+        """List available menu items.
+
+        Args:
+            filter_text: Text to filter menu items (case-insensitive)
+            limit: Maximum number of items to return (default: 100)
+
+        Returns:
+            Dictionary with:
+            - count: int - Number of items found
+            - items: list - Menu items with path, priority, shortcut, type
+        """
+        params: dict[str, Any] = {"action": "list", "limit": limit}
+        if filter_text:
+            params["filter"] = filter_text
+        return self._conn.send_request("menu", params)
+
+    def context(
+        self,
+        method: str,
+        target: str | None = None,
+    ) -> dict[str, Any]:
+        """Execute ContextMenu method on target object.
+
+        Args:
+            method: ContextMenu method name or menu item name
+            target: Target object path (hierarchy or asset path).
+                   If not specified, uses current Selection.
+
+        Returns:
+            Dictionary with execution result
+        """
+        params: dict[str, Any] = {"action": "context", "method": method}
+        if target:
+            params["target"] = target
+        return self._conn.send_request("menu", params)

--- a/unity_cli/client.py
+++ b/unity_cli/client.py
@@ -36,6 +36,7 @@ from unity_cli.exceptions import (
 
 if TYPE_CHECKING:
     from unity_cli.api import (
+        AssetAPI,
         ComponentAPI,
         ConsoleAPI,
         EditorAPI,
@@ -573,6 +574,7 @@ class UnityClient:
 
         # Lazy import to avoid circular dependencies
         from unity_cli.api import (
+            AssetAPI,
             ComponentAPI,
             ConsoleAPI,
             EditorAPI,
@@ -584,6 +586,7 @@ class UnityClient:
         )
 
         # API objects
+        self.asset: AssetAPI = AssetAPI(self._conn)
         self.console: ConsoleAPI = ConsoleAPI(self._conn)
         self.editor: EditorAPI = EditorAPI(self._conn)
         self.gameobject: GameObjectAPI = GameObjectAPI(self._conn)


### PR DESCRIPTION
## Summary
- MenuItem 実行・一覧取得・ContextMenu 実行機能を追加
- Prefab/ScriptableObject アセット作成機能を追加
- Component 追加/削除機能を追加

## 新コマンド

### Menu
```bash
unity-cli menu exec "Edit/Play"
unity-cli menu list -f "Assets"
unity-cli menu context "DoSomething" -t "/Player"
unity-cli menu context "LogInfo" -t "Assets/Data.asset"
```

### Asset
```bash
unity-cli asset prefab -s "Player" -p "Assets/Prefabs/Player.prefab"
unity-cli asset scriptable-object -T "GameConfig" -p "Assets/Data/Config.asset"
unity-cli asset info "Assets/Data/Config.asset"
```

### Component (追加)
```bash
unity-cli component add -t "Player" -T Rigidbody
unity-cli component remove -t "Player" -T Rigidbody
```

## Test plan
- [x] `menu exec` でメニュー実行確認
- [x] `menu list` でメニュー一覧取得確認
- [x] `menu context` でシーン内 GameObject の ContextMenu 実行確認
- [x] `menu context` で ScriptableObject の ContextMenu 実行確認
- [x] `menu context` で Prefab の ContextMenu 実行確認
- [x] `asset prefab` で Prefab 作成確認
- [x] `asset scriptable-object` で ScriptableObject 作成確認
- [x] `component add/remove` でコンポーネント追加/削除確認