### PR TITLE
✨ feat(cli): completionコマンドを追加

### DIFF
--- a/README.jp.md
+++ b/README.jp.md
@@ -92,6 +92,26 @@ unity-cli console --types error --count 10
 unity-relay --port 6500
 ```
 
+## シェル補完
+
+タブ補完を有効にする:
+
+```bash
+# Bash
+unity-cli completion bash >> ~/.bashrc
+
+# Zsh
+unity-cli completion zsh >> ~/.zshrc
+
+# Fish
+unity-cli completion fish > ~/.config/fish/completions/unity-cli.fish
+
+# PowerShell
+unity-cli completion powershell >> $PROFILE
+```
+
+シェルを再起動するか、設定ファイルをsourceして有効化。
+
 ## CLI コマンド
 
 ### プロジェクトを開く

--- a/README.md
+++ b/README.md
@@ -92,6 +92,26 @@ unity-cli console --types error --count 10
 unity-relay --port 6500
 ```
 
+## Shell Completion
+
+Enable tab completion for your shell:
+
+```bash
+# Bash
+unity-cli completion bash >> ~/.bashrc
+
+# Zsh
+unity-cli completion zsh >> ~/.zshrc
+
+# Fish
+unity-cli completion fish > ~/.config/fish/completions/unity-cli.fish
+
+# PowerShell
+unity-cli completion powershell >> $PROFILE
+```
+
+Restart your shell or source the config file to enable completion.
+
 ## CLI Commands
 
 ### Open Project

--- a/unity_cli/cli/app.py
+++ b/unity_cli/cli/app.py
@@ -1365,6 +1365,46 @@ def editor_install(
 
 
 # =============================================================================
+# Completion Command
+# =============================================================================
+
+
+@app.command()
+def completion(
+    shell: Annotated[
+        str,
+        typer.Argument(help="Shell type (bash, zsh, fish, powershell)"),
+    ],
+) -> None:
+    """Generate shell completion script.
+
+    Output can be appended to your shell configuration file:
+
+        unity-cli completion bash >> ~/.bashrc
+
+        unity-cli completion zsh >> ~/.zshrc
+
+        unity-cli completion fish > ~/.config/fish/completions/unity-cli.fish
+
+        unity-cli completion powershell >> $PROFILE
+    """
+    from unity_cli.cli.completion import SUPPORTED_SHELLS, get_completion_script
+
+    shell_lower = shell.lower()
+
+    if shell_lower not in SUPPORTED_SHELLS:
+        print_error(
+            f"Unsupported shell: {shell}. Supported: {', '.join(SUPPORTED_SHELLS)}",
+            "INVALID_SHELL",
+        )
+        raise typer.Exit(1) from None
+
+    script = get_completion_script(shell_lower)
+    # Output to stdout (not via Rich console to avoid formatting)
+    print(script)
+
+
+# =============================================================================
 # Entry Point
 # =============================================================================
 

--- a/unity_cli/cli/completion.py
+++ b/unity_cli/cli/completion.py
@@ -1,0 +1,84 @@
+"""
+Shell Completion Script Generator
+=================================
+
+Generate shell completion scripts for bash, zsh, fish, and powershell.
+Inspired by gh CLI's `gh completion` command.
+
+Usage:
+    unity-cli completion bash >> ~/.bashrc
+    unity-cli completion zsh >> ~/.zshrc
+    unity-cli completion fish > ~/.config/fish/completions/unity-cli.fish
+"""
+
+from __future__ import annotations
+
+import click.shell_completion as sc
+
+# PowerShell completion template (Click doesn't include this by default)
+POWERSHELL_TEMPLATE = """\
+Register-ArgumentCompleter -Native -CommandName %(prog_name)s -ScriptBlock {
+    param($wordToComplete, $commandAst, $cursorPosition)
+    $env:COMP_WORDS = $commandAst.ToString()
+    $env:COMP_CWORD = $commandAst.CommandElements.Count - 1
+    $env:%(complete_var)s = "powershell_complete"
+    %(prog_name)s | ForEach-Object {
+        $type, $value, $help = $_.Split(",", 3)
+        if ($type -eq "plain") {
+            [System.Management.Automation.CompletionResult]::new($value, $value, 'ParameterValue', ($help -replace '_', ' '))
+        }
+    }
+    Remove-Item env:COMP_WORDS, env:COMP_CWORD, env:%(complete_var)s
+}
+"""
+
+# Supported shells
+SUPPORTED_SHELLS = ("bash", "zsh", "fish", "powershell")
+
+
+class PowerShellComplete(sc.ShellComplete):
+    """PowerShell completion support."""
+
+    name = "powershell"
+    source_template = POWERSHELL_TEMPLATE
+
+
+def get_completion_script(shell: str, prog_name: str = "unity-cli") -> str:
+    """Generate shell completion script.
+
+    Args:
+        shell: Target shell (bash, zsh, fish, powershell)
+        prog_name: Program name for completion
+
+    Returns:
+        Shell completion script as string
+
+    Raises:
+        ValueError: If shell is not supported
+    """
+    shell = shell.lower()
+
+    if shell not in SUPPORTED_SHELLS:
+        raise ValueError(f"Unsupported shell: {shell}. Supported: {', '.join(SUPPORTED_SHELLS)}")
+
+    # Map shell name to completion class
+    completion_classes: dict[str, type[sc.ShellComplete]] = {
+        "bash": sc.BashComplete,
+        "zsh": sc.ZshComplete,
+        "fish": sc.FishComplete,
+        "powershell": PowerShellComplete,
+    }
+
+    cls = completion_classes[shell]
+
+    # Generate completion script using Click's internal mechanism
+    # The source_vars method generates the template variables
+    complete_var = f"_{prog_name.upper().replace('-', '_')}_COMPLETE"
+
+    vars_dict = {
+        "prog_name": prog_name,
+        "complete_var": complete_var,
+        "complete_func": f"_{prog_name.replace('-', '_')}_completion",
+    }
+
+    return cls.source_template % vars_dict


### PR DESCRIPTION
## Summary
- シェル補完スクリプト生成機能を追加
- bash, zsh, fish, powershellに対応

## Usage
```bash
unity-cli completion bash >> ~/.bashrc
unity-cli completion zsh >> ~/.zshrc
unity-cli completion fish > ~/.config/fish/completions/unity-cli.fish
unity-cli completion powershell >> $PROFILE
```

## Test plan
- [x] `unity-cli completion bash` が補完スクリプトを出力
- [x] `unity-cli completion zsh` が補完スクリプトを出力
- [x] `unity-cli completion fish` が補完スクリプトを出力
- [x] `unity-cli completion powershell` が補完スクリプトを出力
- [x] `unity-cli completion invalid` がエラーを返す
- [x] ruff check / ruff-format / mypy 通過