### PR TITLE
✨ feat(cli): selection/screenshotコマンドを追加

### DIFF
--- a/UnityBridge/Editor/Tools/EditorSelection.cs
+++ b/UnityBridge/Editor/Tools/EditorSelection.cs
@@ -1,0 +1,126 @@
+using System.Linq;
+using Newtonsoft.Json.Linq;
+using UnityEditor;
+using UnityEngine;
+
+namespace UnityBridge.Tools
+{
+    /// <summary>
+    /// Handler for selection commands.
+    /// Provides information about currently selected objects in the editor.
+    /// </summary>
+    [BridgeTool("selection")]
+    public static class EditorSelection
+    {
+        public static JObject HandleCommand(JObject parameters)
+        {
+            var action = parameters["action"]?.Value<string>() ?? "get";
+
+            return action.ToLowerInvariant() switch
+            {
+                "get" => GetSelection(),
+                _ => throw new ProtocolException(
+                    ErrorCode.InvalidParams,
+                    $"Unknown action: {action}. Valid actions: get")
+            };
+        }
+
+        private static JObject GetSelection()
+        {
+            var activeObject = UnityEditor.Selection.activeObject;
+            var activeGameObject = UnityEditor.Selection.activeGameObject;
+            var activeTransform = UnityEditor.Selection.activeTransform;
+
+            var selectedObjects = UnityEditor.Selection.objects;
+            var selectedGameObjects = UnityEditor.Selection.gameObjects;
+
+            var result = new JObject
+            {
+                ["count"] = UnityEditor.Selection.count,
+                ["activeObject"] = activeObject != null
+                    ? SerializeObject(activeObject)
+                    : null,
+                ["activeGameObject"] = activeGameObject != null
+                    ? SerializeGameObject(activeGameObject)
+                    : null,
+                ["activeInstanceID"] = UnityEditor.Selection.activeInstanceID,
+                ["objects"] = new JArray(
+                    selectedObjects.Select(SerializeObject)),
+                ["gameObjects"] = new JArray(
+                    selectedGameObjects.Select(SerializeGameObject)),
+                ["assetGUIDs"] = new JArray(
+                    UnityEditor.Selection.assetGUIDs)
+            };
+
+            if (activeTransform != null)
+            {
+                result["activeTransform"] = new JObject
+                {
+                    ["position"] = SerializeVector3(activeTransform.position),
+                    ["rotation"] = SerializeVector3(activeTransform.eulerAngles),
+                    ["scale"] = SerializeVector3(activeTransform.localScale)
+                };
+            }
+
+            return result;
+        }
+
+        private static JObject SerializeObject(Object obj)
+        {
+            if (obj == null) return null;
+
+            var result = new JObject
+            {
+                ["name"] = obj.name,
+                ["instanceID"] = obj.GetInstanceID(),
+                ["type"] = obj.GetType().Name
+            };
+
+            var assetPath = AssetDatabase.GetAssetPath(obj);
+            if (!string.IsNullOrEmpty(assetPath))
+            {
+                result["assetPath"] = assetPath;
+            }
+
+            return result;
+        }
+
+        private static JObject SerializeGameObject(GameObject go)
+        {
+            if (go == null) return null;
+
+            return new JObject
+            {
+                ["name"] = go.name,
+                ["instanceID"] = go.GetInstanceID(),
+                ["tag"] = go.tag,
+                ["layer"] = go.layer,
+                ["layerName"] = LayerMask.LayerToName(go.layer),
+                ["activeSelf"] = go.activeSelf,
+                ["activeInHierarchy"] = go.activeInHierarchy,
+                ["isStatic"] = go.isStatic,
+                ["scenePath"] = GetScenePath(go),
+                ["componentCount"] = go.GetComponents(typeof(UnityEngine.Component)).Length
+            };
+        }
+
+        private static string GetScenePath(GameObject go)
+        {
+            var path = go.name;
+            var parent = go.transform.parent;
+
+            while (parent != null)
+            {
+                path = parent.name + "/" + path;
+                parent = parent.parent;
+            }
+
+            return path;
+        }
+
+        private static JArray SerializeVector3(Vector3 v)
+        {
+            return new JArray(v.x, v.y, v.z);
+        }
+    }
+}

--- a/UnityBridge/Editor/Tools/EditorSelection.cs.meta
+++ b/UnityBridge/Editor/Tools/EditorSelection.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: c4070b71f3e0843458d0b173b99b27dd

--- a/UnityBridge/Editor/Tools/Screenshot.cs
+++ b/UnityBridge/Editor/Tools/Screenshot.cs
@@ -1,0 +1,207 @@
+using System;
+using System.IO;
+using Newtonsoft.Json.Linq;
+using UnityEditor;
+using UnityEngine;
+
+namespace UnityBridge.Tools
+{
+    /// <summary>
+    /// Handler for screenshot commands.
+    /// Captures screenshots from SceneView or GameView.
+    /// </summary>
+    [BridgeTool("screenshot")]
+    public static class Screenshot
+    {
+        public static JObject HandleCommand(JObject parameters)
+        {
+            var action = parameters["action"]?.Value<string>() ?? "capture";
+
+            return action.ToLowerInvariant() switch
+            {
+                "capture" => Capture(parameters),
+                _ => throw new ProtocolException(
+                    ErrorCode.InvalidParams,
+                    $"Unknown action: {action}. Valid actions: capture")
+            };
+        }
+
+        private static JObject Capture(JObject parameters)
+        {
+            var source = parameters["source"]?.Value<string>() ?? "game";
+            var path = parameters["path"]?.Value<string>();
+            var superSize = parameters["superSize"]?.Value<int>() ?? 1;
+
+            if (string.IsNullOrEmpty(path))
+            {
+                var timestamp = DateTime.Now.ToString("yyyyMMdd_HHmmss");
+                var projectPath = Directory.GetCurrentDirectory();
+                path = Path.Combine(projectPath, $"Screenshots/screenshot_{timestamp}.png");
+            }
+
+            var directory = Path.GetDirectoryName(path);
+            if (!string.IsNullOrEmpty(directory) && !Directory.Exists(directory))
+            {
+                Directory.CreateDirectory(directory);
+            }
+
+            return source.ToLowerInvariant() switch
+            {
+                "game" => CaptureGameView(path, superSize),
+                "scene" => CaptureSceneView(path),
+                "camera" => CaptureCamera(parameters),
+                _ => throw new ProtocolException(
+                    ErrorCode.InvalidParams,
+                    $"Unknown source: {source}. Valid sources: game, scene, camera")
+            };
+        }
+
+        private static JObject CaptureGameView(string path, int superSize)
+        {
+            superSize = Mathf.Clamp(superSize, 1, 4);
+
+            ScreenCapture.CaptureScreenshot(path, superSize);
+
+            return new JObject
+            {
+                ["message"] = $"GameView screenshot captured",
+                ["path"] = path,
+                ["source"] = "game",
+                ["superSize"] = superSize,
+                ["note"] = "Screenshot will be saved after the current frame renders. Editor focus required."
+            };
+        }
+
+        private static JObject CaptureCamera(JObject parameters)
+        {
+            var path = parameters["path"]?.Value<string>();
+            var width = parameters["width"]?.Value<int>() ?? 1920;
+            var height = parameters["height"]?.Value<int>() ?? 1080;
+            var cameraName = parameters["camera"]?.Value<string>();
+
+            if (string.IsNullOrEmpty(path))
+            {
+                var timestamp = DateTime.Now.ToString("yyyyMMdd_HHmmss");
+                var projectPath = Directory.GetCurrentDirectory();
+                path = Path.Combine(projectPath, $"Screenshots/camera_{timestamp}.png");
+            }
+
+            var directory = Path.GetDirectoryName(path);
+            if (!string.IsNullOrEmpty(directory) && !Directory.Exists(directory))
+            {
+                Directory.CreateDirectory(directory);
+            }
+
+            Camera camera = null;
+            if (!string.IsNullOrEmpty(cameraName))
+            {
+                var cameraGo = GameObject.Find(cameraName);
+                if (cameraGo != null)
+                {
+                    camera = cameraGo.GetComponent<Camera>();
+                }
+            }
+
+            if (camera == null)
+            {
+                camera = Camera.main;
+            }
+
+            if (camera == null)
+            {
+                throw new ProtocolException(
+                    ErrorCode.InvalidParams,
+                    "No camera found. Specify camera name or ensure a Main Camera exists.");
+            }
+
+            width = Mathf.Max(1, width);
+            height = Mathf.Max(1, height);
+
+            var prevTarget = camera.targetTexture;
+            var prevActive = RenderTexture.active;
+            var renderTexture = RenderTexture.GetTemporary(width, height, 24, RenderTextureFormat.ARGB32);
+
+            try
+            {
+                camera.targetTexture = renderTexture;
+                camera.Render();
+
+                RenderTexture.active = renderTexture;
+                var texture = new Texture2D(width, height, TextureFormat.RGBA32, false);
+                texture.ReadPixels(new Rect(0, 0, width, height), 0, 0);
+                texture.Apply();
+
+                var bytes = texture.EncodeToPNG();
+                File.WriteAllBytes(path, bytes);
+
+                UnityEngine.Object.DestroyImmediate(texture);
+
+                return new JObject
+                {
+                    ["message"] = "Camera screenshot captured",
+                    ["path"] = path,
+                    ["source"] = "camera",
+                    ["width"] = width,
+                    ["height"] = height,
+                    ["camera"] = camera.name
+                };
+            }
+            finally
+            {
+                camera.targetTexture = prevTarget;
+                RenderTexture.active = prevActive;
+                RenderTexture.ReleaseTemporary(renderTexture);
+            }
+        }
+
+        private static JObject CaptureSceneView(string path)
+        {
+            var sceneView = SceneView.lastActiveSceneView;
+
+            if (sceneView == null)
+            {
+                throw new ProtocolException(
+                    ErrorCode.InvalidParams,
+                    "No active SceneView found");
+            }
+
+            var camera = sceneView.camera;
+            var width = (int)sceneView.position.width;
+            var height = (int)sceneView.position.height;
+
+            var renderTexture = new RenderTexture(width, height, 24);
+            var previousTarget = camera.targetTexture;
+
+            try
+            {
+                camera.targetTexture = renderTexture;
+                camera.Render();
+
+                var texture = new Texture2D(width, height, TextureFormat.RGB24, false);
+                RenderTexture.active = renderTexture;
+                texture.ReadPixels(new Rect(0, 0, width, height), 0, 0);
+                texture.Apply();
+
+                var bytes = texture.EncodeToPNG();
+                File.WriteAllBytes(path, bytes);
+
+                UnityEngine.Object.DestroyImmediate(texture);
+
+                return new JObject
+                {
+                    ["message"] = "SceneView screenshot captured",
+                    ["path"] = path,
+                    ["source"] = "scene",
+                    ["width"] = width,
+                    ["height"] = height
+                };
+            }
+            finally
+            {
+                camera.targetTexture = previousTarget;
+                RenderTexture.active = null;
+                UnityEngine.Object.DestroyImmediate(renderTexture);
+            }
+        }
+    }
+}

--- a/UnityBridge/Editor/Tools/Screenshot.cs.meta
+++ b/UnityBridge/Editor/Tools/Screenshot.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: adfeba7999cf64b9d87df84528ac2761

--- a/unity_cli/api/__init__.py
+++ b/unity_cli/api/__init__.py
@@ -12,6 +12,8 @@ from unity_cli.api.gameobject import GameObjectAPI
 from unity_cli.api.material import MaterialAPI
 from unity_cli.api.menu import MenuAPI
 from unity_cli.api.scene import SceneAPI
+from unity_cli.api.screenshot import ScreenshotAPI
+from unity_cli.api.selection import SelectionAPI
 from unity_cli.api.tests import TestAPI
 
 __all__ = [
@@ -23,5 +25,7 @@ __all__ = [
     "MaterialAPI",
     "MenuAPI",
     "SceneAPI",
+    "ScreenshotAPI",
+    "SelectionAPI",
     "TestAPI",
 ]

--- a/unity_cli/api/screenshot.py
+++ b/unity_cli/api/screenshot.py
@@ -1,0 +1,59 @@
+"""Screenshot API for Unity CLI."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any, Literal
+
+if TYPE_CHECKING:
+    from unity_cli.client import RelayConnection
+
+
+class ScreenshotAPI:
+    """Screenshot capture operations."""
+
+    def __init__(self, conn: RelayConnection) -> None:
+        self._conn = conn
+
+    def capture(
+        self,
+        source: Literal["game", "scene", "camera"] = "game",
+        path: str | None = None,
+        super_size: int = 1,
+        width: int | None = None,
+        height: int | None = None,
+        camera: str | None = None,
+    ) -> dict[str, Any]:
+        """Capture a screenshot from GameView, SceneView, or Camera.
+
+        Args:
+            source: "game" for GameView (async, requires editor focus),
+                    "scene" for SceneView,
+                    "camera" for Camera.Render (sync, focus-independent)
+            path: Output file path. If not specified, saves to Screenshots/ with timestamp
+            super_size: Resolution multiplier for GameView (1-4). Ignored for scene/camera.
+            width: Image width for camera source (default: 1920)
+            height: Image height for camera source (default: 1080)
+            camera: Camera GameObject name for camera source. Uses Main Camera if not specified.
+
+        Returns:
+            Dictionary with capture result including:
+            - message: Status message
+            - path: Output file path
+            - source: Capture source ("game", "scene", or "camera")
+            - width/height: Image dimensions (for scene/camera captures)
+            - camera: Camera name (for camera captures)
+        """
+        params: dict[str, Any] = {
+            "action": "capture",
+            "source": source,
+            "superSize": super_size,
+        }
+        if path is not None:
+            params["path"] = path
+        if width is not None:
+            params["width"] = width
+        if height is not None:
+            params["height"] = height
+        if camera is not None:
+            params["camera"] = camera
+        return self._conn.send_request("screenshot", params)

--- a/unity_cli/api/selection.py
+++ b/unity_cli/api/selection.py
@@ -1,0 +1,30 @@
+"""Selection API for Unity CLI."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from unity_cli.client import RelayConnection
+
+
+class SelectionAPI:
+    """Editor selection operations."""
+
+    def __init__(self, conn: RelayConnection) -> None:
+        self._conn = conn
+
+    def get(self) -> dict[str, Any]:
+        """Get current editor selection.
+
+        Returns:
+            Dictionary with selection information including:
+            - count: Number of selected objects
+            - activeObject: Currently active object (name, type, instanceID)
+            - activeGameObject: Active GameObject details (name, tag, layer, etc.)
+            - activeTransform: Transform of active object (position, rotation, scale)
+            - objects: List of all selected objects
+            - gameObjects: List of all selected GameObjects
+            - assetGUIDs: List of selected asset GUIDs
+        """
+        return self._conn.send_request("selection", {"action": "get"})

--- a/unity_cli/client.py
+++ b/unity_cli/client.py
@@ -44,6 +44,8 @@ if TYPE_CHECKING:
         MaterialAPI,
         MenuAPI,
         SceneAPI,
+        ScreenshotAPI,
+        SelectionAPI,
         TestAPI,
     )
 
@@ -582,6 +584,8 @@ class UnityClient:
             MaterialAPI,
             MenuAPI,
             SceneAPI,
+            ScreenshotAPI,
+            SelectionAPI,
             TestAPI,
         )
 
@@ -595,6 +599,8 @@ class UnityClient:
         self.material: MaterialAPI = MaterialAPI(self._conn)
         self.tests: TestAPI = TestAPI(self._conn)
         self.menu: MenuAPI = MenuAPI(self._conn)
+        self.selection: SelectionAPI = SelectionAPI(self._conn)
+        self.screenshot: ScreenshotAPI = ScreenshotAPI(self._conn)
 
     def list_instances(self) -> list[dict[str, Any]]:
         """List all connected Unity instances.


### PR DESCRIPTION
## Summary

- `selection`コマンド追加: エディタで選択中のオブジェクト情報を取得
- `screenshot`コマンド追加: 3つのソースからスクリーンショット取得
  - `--source game`: GameView (ScreenCapture方式、フォーカス必要)
  - `--source scene`: SceneView
  - `--source camera`: Camera.Render方式 (同期、フォーカス不要)

## Test plan

- [ ] `unity-cli selection` で選択中オブジェクト情報が取得できる
- [ ] `unity-cli screenshot --source game` でGameViewスクリーンショット取得
- [ ] `unity-cli screenshot --source scene` でSceneViewスクリーンショット取得
- [ ] `unity-cli screenshot --source camera` でCamera経由スクリーンショット取得（フォーカス不要）
- [ ] `--width`, `--height`, `--camera` オプションが機能する

Closes #4