### PR TITLE
🐛 fix(cli): シェル補完を静的スクリプトに変更

### DIFF
--- a/unity_cli/cli/completion.py
+++ b/unity_cli/cli/completion.py
@@ -2,8 +2,7 @@
 Shell Completion Script Generator
 =================================
 
-Generate shell completion scripts for bash, zsh, fish, and powershell.
-Inspired by gh CLI's `gh completion` command.
+Generate static shell completion scripts for bash, zsh, fish, and powershell.
 
 Usage:
     unity-cli completion bash >> ~/.bashrc
@@ -13,34 +12,271 @@ Usage:
 
 from __future__ import annotations
 
-import click.shell_completion as sc
-
-# PowerShell completion template (Click doesn't include this by default)
-POWERSHELL_TEMPLATE = """\
-Register-ArgumentCompleter -Native -CommandName %(prog_name)s -ScriptBlock {
-    param($wordToComplete, $commandAst, $cursorPosition)
-    $env:COMP_WORDS = $commandAst.ToString()
-    $env:COMP_CWORD = $commandAst.CommandElements.Count - 1
-    $env:%(complete_var)s = "powershell_complete"
-    %(prog_name)s | ForEach-Object {
-        $type, $value, $help = $_.Split(",", 3)
-        if ($type -eq "plain") {
-            [System.Management.Automation.CompletionResult]::new($value, $value, 'ParameterValue', ($help -replace '_', ' '))
-        }
-    }
-    Remove-Item env:COMP_WORDS, env:COMP_CWORD, env:%(complete_var)s
-}
-"""
-
 # Supported shells
 SUPPORTED_SHELLS = ("bash", "zsh", "fish", "powershell")
 
+# Static completion scripts
 
-class PowerShellComplete(sc.ShellComplete):
-    """PowerShell completion support."""
+ZSH_SCRIPT = """\
+#compdef unity-cli
 
-    name = "powershell"
-    source_template = POWERSHELL_TEMPLATE
+_unity_cli() {
+    local -a commands
+    local -a global_opts
+
+    global_opts=(
+        '--relay-host[Relay server host]:host:'
+        '--relay-port[Relay server port]:port:'
+        '--instance[Target Unity instance]:instance:'
+        '-i[Target Unity instance]:instance:'
+        '--timeout[Timeout in seconds]:timeout:'
+        '-t[Timeout in seconds]:timeout:'
+        '--json[Output JSON format]'
+        '-j[Output JSON format]'
+        '--help[Show help]'
+    )
+
+    commands=(
+        'instances:List connected Unity instances'
+        'state:Get editor state'
+        'play:Enter play mode'
+        'stop:Exit play mode'
+        'pause:Toggle pause'
+        'refresh:Refresh asset database'
+        'open:Open Unity project'
+        'completion:Generate shell completion script'
+        'console:Console log commands'
+        'scene:Scene management commands'
+        'tests:Test execution commands'
+        'gameobject:GameObject commands'
+        'component:Component commands'
+        'menu:Menu item commands'
+        'asset:Asset commands'
+        'config:Configuration commands'
+        'project:Project information'
+        'editor:Unity Editor management'
+    )
+
+    _arguments -C \\
+        $global_opts \\
+        '1:command:->command' \\
+        '*::arg:->args'
+
+    case $state in
+        command)
+            _describe -t commands 'unity-cli command' commands
+            ;;
+        args)
+            case $words[1] in
+                console)
+                    local -a console_cmds
+                    console_cmds=('get:Get console logs' 'clear:Clear console logs')
+                    _describe -t commands 'console command' console_cmds
+                    ;;
+                scene)
+                    local -a scene_cmds
+                    scene_cmds=('active:Get active scene' 'hierarchy:Get scene hierarchy' 'load:Load scene' 'save:Save scene')
+                    _describe -t commands 'scene command' scene_cmds
+                    ;;
+                tests)
+                    local -a tests_cmds
+                    tests_cmds=('run:Run tests' 'list:List tests' 'status:Test status')
+                    _describe -t commands 'tests command' tests_cmds
+                    ;;
+                gameobject)
+                    local -a go_cmds
+                    go_cmds=('find:Find GameObjects' 'create:Create GameObject' 'modify:Modify GameObject' 'delete:Delete GameObject')
+                    _describe -t commands 'gameobject command' go_cmds
+                    ;;
+                component)
+                    local -a comp_cmds
+                    comp_cmds=('list:List components' 'inspect:Inspect component' 'add:Add component' 'remove:Remove component')
+                    _describe -t commands 'component command' comp_cmds
+                    ;;
+                menu)
+                    local -a menu_cmds
+                    menu_cmds=('exec:Execute menu item' 'list:List menu items' 'context:Execute ContextMenu')
+                    _describe -t commands 'menu command' menu_cmds
+                    ;;
+                asset)
+                    local -a asset_cmds
+                    asset_cmds=('prefab:Create prefab' 'scriptable-object:Create ScriptableObject' 'info:Asset info')
+                    _describe -t commands 'asset command' asset_cmds
+                    ;;
+                config)
+                    local -a config_cmds
+                    config_cmds=('show:Show config' 'init:Initialize config')
+                    _describe -t commands 'config command' config_cmds
+                    ;;
+                project)
+                    local -a project_cmds
+                    project_cmds=('info:Project info' 'version:Unity version' 'packages:List packages' 'tags:Tags and layers' 'quality:Quality settings' 'assemblies:Assembly definitions')
+                    _describe -t commands 'project command' project_cmds
+                    ;;
+                editor)
+                    local -a editor_cmds
+                    editor_cmds=('list:List editors' 'install:Install editor')
+                    _describe -t commands 'editor command' editor_cmds
+                    ;;
+                completion)
+                    local -a shells
+                    shells=('bash' 'zsh' 'fish' 'powershell')
+                    _describe -t shells 'shell' shells
+                    ;;
+            esac
+            ;;
+    esac
+}
+
+compdef _unity_cli unity-cli
+"""
+
+BASH_SCRIPT = """\
+_unity_cli() {
+    local cur prev commands
+    COMPREPLY=()
+    cur="${COMP_WORDS[COMP_CWORD]}"
+    prev="${COMP_WORDS[COMP_CWORD-1]}"
+
+    commands="instances state play stop pause refresh open completion console scene tests gameobject component menu asset config project editor"
+
+    case "${prev}" in
+        unity-cli)
+            COMPREPLY=( $(compgen -W "${commands}" -- ${cur}) )
+            return 0
+            ;;
+        console)
+            COMPREPLY=( $(compgen -W "get clear" -- ${cur}) )
+            return 0
+            ;;
+        scene)
+            COMPREPLY=( $(compgen -W "active hierarchy load save" -- ${cur}) )
+            return 0
+            ;;
+        tests)
+            COMPREPLY=( $(compgen -W "run list status" -- ${cur}) )
+            return 0
+            ;;
+        gameobject)
+            COMPREPLY=( $(compgen -W "find create modify delete" -- ${cur}) )
+            return 0
+            ;;
+        component)
+            COMPREPLY=( $(compgen -W "list inspect add remove" -- ${cur}) )
+            return 0
+            ;;
+        menu)
+            COMPREPLY=( $(compgen -W "exec list context" -- ${cur}) )
+            return 0
+            ;;
+        asset)
+            COMPREPLY=( $(compgen -W "prefab scriptable-object info" -- ${cur}) )
+            return 0
+            ;;
+        config)
+            COMPREPLY=( $(compgen -W "show init" -- ${cur}) )
+            return 0
+            ;;
+        project)
+            COMPREPLY=( $(compgen -W "info version packages tags quality assemblies" -- ${cur}) )
+            return 0
+            ;;
+        editor)
+            COMPREPLY=( $(compgen -W "list install" -- ${cur}) )
+            return 0
+            ;;
+        completion)
+            COMPREPLY=( $(compgen -W "bash zsh fish powershell" -- ${cur}) )
+            return 0
+            ;;
+    esac
+}
+
+complete -F _unity_cli unity-cli
+"""
+
+FISH_SCRIPT = """\
+# unity-cli fish completion
+
+set -l commands instances state play stop pause refresh open completion console scene tests gameobject component menu asset config project editor
+
+complete -c unity-cli -f
+complete -c unity-cli -n "not __fish_seen_subcommand_from $commands" -a instances -d 'List connected Unity instances'
+complete -c unity-cli -n "not __fish_seen_subcommand_from $commands" -a state -d 'Get editor state'
+complete -c unity-cli -n "not __fish_seen_subcommand_from $commands" -a play -d 'Enter play mode'
+complete -c unity-cli -n "not __fish_seen_subcommand_from $commands" -a stop -d 'Exit play mode'
+complete -c unity-cli -n "not __fish_seen_subcommand_from $commands" -a pause -d 'Toggle pause'
+complete -c unity-cli -n "not __fish_seen_subcommand_from $commands" -a refresh -d 'Refresh asset database'
+complete -c unity-cli -n "not __fish_seen_subcommand_from $commands" -a open -d 'Open Unity project'
+complete -c unity-cli -n "not __fish_seen_subcommand_from $commands" -a completion -d 'Generate shell completion'
+complete -c unity-cli -n "not __fish_seen_subcommand_from $commands" -a console -d 'Console commands'
+complete -c unity-cli -n "not __fish_seen_subcommand_from $commands" -a scene -d 'Scene commands'
+complete -c unity-cli -n "not __fish_seen_subcommand_from $commands" -a tests -d 'Test commands'
+complete -c unity-cli -n "not __fish_seen_subcommand_from $commands" -a gameobject -d 'GameObject commands'
+complete -c unity-cli -n "not __fish_seen_subcommand_from $commands" -a component -d 'Component commands'
+complete -c unity-cli -n "not __fish_seen_subcommand_from $commands" -a menu -d 'Menu commands'
+complete -c unity-cli -n "not __fish_seen_subcommand_from $commands" -a asset -d 'Asset commands'
+complete -c unity-cli -n "not __fish_seen_subcommand_from $commands" -a config -d 'Config commands'
+complete -c unity-cli -n "not __fish_seen_subcommand_from $commands" -a project -d 'Project commands'
+complete -c unity-cli -n "not __fish_seen_subcommand_from $commands" -a editor -d 'Editor commands'
+
+# Subcommands
+complete -c unity-cli -n "__fish_seen_subcommand_from console" -a "get clear"
+complete -c unity-cli -n "__fish_seen_subcommand_from scene" -a "active hierarchy load save"
+complete -c unity-cli -n "__fish_seen_subcommand_from tests" -a "run list status"
+complete -c unity-cli -n "__fish_seen_subcommand_from gameobject" -a "find create modify delete"
+complete -c unity-cli -n "__fish_seen_subcommand_from component" -a "list inspect add remove"
+complete -c unity-cli -n "__fish_seen_subcommand_from menu" -a "exec list context"
+complete -c unity-cli -n "__fish_seen_subcommand_from asset" -a "prefab scriptable-object info"
+complete -c unity-cli -n "__fish_seen_subcommand_from config" -a "show init"
+complete -c unity-cli -n "__fish_seen_subcommand_from project" -a "info version packages tags quality assemblies"
+complete -c unity-cli -n "__fish_seen_subcommand_from editor" -a "list install"
+complete -c unity-cli -n "__fish_seen_subcommand_from completion" -a "bash zsh fish powershell"
+
+# Global options
+complete -c unity-cli -l relay-host -d 'Relay server host'
+complete -c unity-cli -l relay-port -d 'Relay server port'
+complete -c unity-cli -l instance -s i -d 'Target Unity instance'
+complete -c unity-cli -l timeout -s t -d 'Timeout in seconds'
+complete -c unity-cli -l json -s j -d 'Output JSON format'
+complete -c unity-cli -l help -d 'Show help'
+"""
+
+POWERSHELL_SCRIPT = """\
+Register-ArgumentCompleter -Native -CommandName unity-cli -ScriptBlock {
+    param($wordToComplete, $commandAst, $cursorPosition)
+
+    $commands = @{
+        '' = @('instances', 'state', 'play', 'stop', 'pause', 'refresh', 'open', 'completion', 'console', 'scene', 'tests', 'gameobject', 'component', 'menu', 'asset', 'config', 'project', 'editor')
+        'console' = @('get', 'clear')
+        'scene' = @('active', 'hierarchy', 'load', 'save')
+        'tests' = @('run', 'list', 'status')
+        'gameobject' = @('find', 'create', 'modify', 'delete')
+        'component' = @('list', 'inspect', 'add', 'remove')
+        'menu' = @('exec', 'list', 'context')
+        'asset' = @('prefab', 'scriptable-object', 'info')
+        'config' = @('show', 'init')
+        'project' = @('info', 'version', 'packages', 'tags', 'quality', 'assemblies')
+        'editor' = @('list', 'install')
+        'completion' = @('bash', 'zsh', 'fish', 'powershell')
+    }
+
+    $elements = $commandAst.CommandElements
+    $subcommand = ''
+    if ($elements.Count -gt 1) {
+        $subcommand = $elements[1].Extent.Text
+    }
+
+    $completions = $commands[$subcommand]
+    if (-not $completions) {
+        $completions = $commands['']
+    }
+
+    $completions | Where-Object { $_ -like "$wordToComplete*" } | ForEach-Object {
+        [System.Management.Automation.CompletionResult]::new($_, $_, 'ParameterValue', $_)
+    }
+}
+"""
 
 
 def get_completion_script(shell: str, prog_name: str = "unity-cli") -> str:
@@ -48,7 +284,7 @@ def get_completion_script(shell: str, prog_name: str = "unity-cli") -> str:
 
     Args:
         shell: Target shell (bash, zsh, fish, powershell)
-        prog_name: Program name for completion
+        prog_name: Program name (unused, kept for compatibility)
 
     Returns:
         Shell completion script as string
@@ -61,24 +297,11 @@ def get_completion_script(shell: str, prog_name: str = "unity-cli") -> str:
     if shell not in SUPPORTED_SHELLS:
         raise ValueError(f"Unsupported shell: {shell}. Supported: {', '.join(SUPPORTED_SHELLS)}")
 
-    # Map shell name to completion class
-    completion_classes: dict[str, type[sc.ShellComplete]] = {
-        "bash": sc.BashComplete,
-        "zsh": sc.ZshComplete,
-        "fish": sc.FishComplete,
-        "powershell": PowerShellComplete,
+    scripts = {
+        "bash": BASH_SCRIPT,
+        "zsh": ZSH_SCRIPT,
+        "fish": FISH_SCRIPT,
+        "powershell": POWERSHELL_SCRIPT,
     }
 
-    cls = completion_classes[shell]
-
-    # Generate completion script using Click's internal mechanism
-    # The source_vars method generates the template variables
-    complete_var = f"_{prog_name.upper().replace('-', '_')}_COMPLETE"
-
-    vars_dict = {
-        "prog_name": prog_name,
-        "complete_var": complete_var,
-        "complete_func": f"_{prog_name.replace('-', '_')}_completion",
-    }
-
-    return cls.source_template % vars_dict
+    return scripts[shell]


### PR DESCRIPTION
## Summary
- Click/Typerの動的補完機構が `Shell complete not supported` エラーを出す問題を修正
- 静的な補完スクリプト（zsh/bash/fish/powershell）に変更

## Changes
- `unity_cli/cli/completion.py`: 動的生成から静的スクリプトに変更

## Test plan
- [x] `uv tool install . --force` で再インストール
- [x] `unity-cli completion zsh > ~/.zsh/plugins/unity-cli.zsh` で補完ファイル更新
- [x] `source ~/.zshrc` 後に `unity-cli <TAB>` で補完が動作することを確認