### PR TITLE
テスト実行をポーリング方式に変更

### DIFF
--- a/UnityBridge/Editor/Tools/Tests.cs
+++ b/UnityBridge/Editor/Tools/Tests.cs
@@ -148,21 +148,7 @@ namespace UnityBridge.Tools
                 };
                 Api.RegisterCallbacks(_activeCollector, 1);
 
-                // Check for synchronous execution (EditMode only)
-                var sync = parameters["synchronous"]?.Value<bool>() ?? false;
                 var executionSettings = new ExecutionSettings(filter);
-
-                if (sync && testMode == TestMode.EditMode)
-                {
-                    executionSettings.runSynchronously = true;
-                    Api.Execute(executionSettings);
-
-                    // Synchronous execution completes immediately
-                    var result = BuildResultJson(_activeCollector);
-                    Api.UnregisterCallbacks(_activeCollector);
-                    _activeCollector = null;
-                    return Task.FromResult(result);
-                }
 
                 // Async execution - wait for completion using TaskCompletionSource
                 var tcs = new TaskCompletionSource<JObject>(TaskCreationOptions.RunContinuationsAsynchronously);

--- a/unity_cli/api/tests.py
+++ b/unity_cli/api/tests.py
@@ -22,7 +22,6 @@ class TestAPI:
         categories: list[str] | None = None,
         assemblies: list[str] | None = None,
         group_pattern: str | None = None,
-        synchronous: bool = False,
     ) -> dict[str, Any]:
         """Run Unity tests with optional filtering.
 
@@ -32,7 +31,6 @@ class TestAPI:
             categories: Test categories to run
             assemblies: Assembly names to run tests from
             group_pattern: Regex pattern for test names/namespaces
-            synchronous: Run synchronously (EditMode only)
 
         Returns:
             Dictionary with test run results
@@ -47,8 +45,6 @@ class TestAPI:
             params["assemblies"] = assemblies
         if group_pattern:
             params["groupPattern"] = group_pattern
-        if synchronous:
-            params["synchronous"] = synchronous
 
         return self._conn.send_request("tests", params)
 


### PR DESCRIPTION
## Summary
- 同期実行モード(`--sync`)を廃止
- 非同期実行+ポーリングによるリアルタイム進捗表示に変更
- `--no-wait`オプションで即時返却も可能

## Test plan
- [ ] `u tests run edit` で進捗表示が出ることを確認
- [ ] `u tests run edit --no-wait` で即時返却されることを確認
- [ ] Ctrl+C でポーリング中断後、`u tests status` で状態確認可能