### PR TITLE
未テストAPIモジュールのユニットテスト追加

### DIFF
--- a/tests/test_console_api.py
+++ b/tests/test_console_api.py
@@ -11,11 +11,13 @@ from unity_cli.api.console import ConsoleAPI
 
 @pytest.fixture
 def mock_conn() -> MagicMock:
+    """Create a mock relay connection."""
     return MagicMock()
 
 
 @pytest.fixture
 def sut(mock_conn: MagicMock) -> ConsoleAPI:
+    """Create a ConsoleAPI instance with mock connection."""
     return ConsoleAPI(mock_conn)
 
 
@@ -23,6 +25,7 @@ class TestGet:
     """get() メソッドのテスト"""
 
     def test_get_sends_console_command(self, sut: ConsoleAPI, mock_conn: MagicMock) -> None:
+        """Send 'console' as the command name."""
         mock_conn.send_request.return_value = {}
 
         sut.get()
@@ -30,6 +33,7 @@ class TestGet:
         assert mock_conn.send_request.call_args[0][0] == "console"
 
     def test_get_sends_read_action_with_defaults(self, sut: ConsoleAPI, mock_conn: MagicMock) -> None:
+        """Send action='read' with format='detailed' and include_stacktrace=False."""
         mock_conn.send_request.return_value = {}
 
         sut.get()
@@ -40,6 +44,7 @@ class TestGet:
         assert params["include_stacktrace"] is False
 
     def test_get_with_types(self, sut: ConsoleAPI, mock_conn: MagicMock) -> None:
+        """Include types key when types list is provided."""
         mock_conn.send_request.return_value = {}
 
         sut.get(types=["error", "warning"])
@@ -48,6 +53,7 @@ class TestGet:
         assert params["types"] == ["error", "warning"]
 
     def test_get_without_types_excludes_types_key(self, sut: ConsoleAPI, mock_conn: MagicMock) -> None:
+        """Exclude types key when types is not provided."""
         mock_conn.send_request.return_value = {}
 
         sut.get()
@@ -56,6 +62,7 @@ class TestGet:
         assert "types" not in params
 
     def test_get_with_count(self, sut: ConsoleAPI, mock_conn: MagicMock) -> None:
+        """Include count key when count is provided."""
         mock_conn.send_request.return_value = {}
 
         sut.get(count=10)
@@ -64,6 +71,7 @@ class TestGet:
         assert params["count"] == 10
 
     def test_get_without_count_excludes_count_key(self, sut: ConsoleAPI, mock_conn: MagicMock) -> None:
+        """Exclude count key when count is None."""
         mock_conn.send_request.return_value = {}
 
         sut.get()
@@ -72,6 +80,7 @@ class TestGet:
         assert "count" not in params
 
     def test_get_with_filter_text(self, sut: ConsoleAPI, mock_conn: MagicMock) -> None:
+        """Map filter_text to 'search' key in params."""
         mock_conn.send_request.return_value = {}
 
         sut.get(filter_text="NullReference")
@@ -80,6 +89,7 @@ class TestGet:
         assert params["search"] == "NullReference"
 
     def test_get_with_stacktrace(self, sut: ConsoleAPI, mock_conn: MagicMock) -> None:
+        """Set include_stacktrace to True when requested."""
         mock_conn.send_request.return_value = {}
 
         sut.get(include_stacktrace=True)
@@ -88,6 +98,7 @@ class TestGet:
         assert params["include_stacktrace"] is True
 
     def test_get_with_simple_format(self, sut: ConsoleAPI, mock_conn: MagicMock) -> None:
+        """Send format='simple' when specified."""
         mock_conn.send_request.return_value = {}
 
         sut.get(format="simple")
@@ -100,6 +111,7 @@ class TestClear:
     """clear() メソッドのテスト"""
 
     def test_clear_sends_console_command(self, sut: ConsoleAPI, mock_conn: MagicMock) -> None:
+        """Send 'console' as the command name."""
         mock_conn.send_request.return_value = {}
 
         sut.clear()
@@ -107,6 +119,7 @@ class TestClear:
         assert mock_conn.send_request.call_args[0][0] == "console"
 
     def test_clear_sends_clear_action(self, sut: ConsoleAPI, mock_conn: MagicMock) -> None:
+        """Send action='clear' to clear console logs."""
         mock_conn.send_request.return_value = {}
 
         sut.clear()

--- a/tests/test_editor_api.py
+++ b/tests/test_editor_api.py
@@ -11,11 +11,13 @@ from unity_cli.api.editor import EditorAPI
 
 @pytest.fixture
 def mock_conn() -> MagicMock:
+    """Create a mock relay connection."""
     return MagicMock()
 
 
 @pytest.fixture
 def sut(mock_conn: MagicMock) -> EditorAPI:
+    """Create an EditorAPI instance with mock connection."""
     return EditorAPI(mock_conn)
 
 
@@ -23,6 +25,7 @@ class TestPlay:
     """play() メソッドのテスト"""
 
     def test_play_sends_playmode_command(self, sut: EditorAPI, mock_conn: MagicMock) -> None:
+        """Send 'playmode' as the command name."""
         mock_conn.send_request.return_value = {}
 
         sut.play()
@@ -30,6 +33,7 @@ class TestPlay:
         assert mock_conn.send_request.call_args[0][0] == "playmode"
 
     def test_play_sends_enter_action(self, sut: EditorAPI, mock_conn: MagicMock) -> None:
+        """Send action='enter' to enter play mode."""
         mock_conn.send_request.return_value = {}
 
         sut.play()
@@ -38,6 +42,7 @@ class TestPlay:
         assert params == {"action": "enter"}
 
     def test_play_returns_response(self, sut: EditorAPI, mock_conn: MagicMock) -> None:
+        """Return the response from send_request."""
         expected = {"isPlaying": True}
         mock_conn.send_request.return_value = expected
 
@@ -50,6 +55,7 @@ class TestPause:
     """pause() メソッドのテスト"""
 
     def test_pause_sends_pause_action(self, sut: EditorAPI, mock_conn: MagicMock) -> None:
+        """Send action='pause' to pause the game."""
         mock_conn.send_request.return_value = {}
 
         sut.pause()
@@ -62,6 +68,7 @@ class TestUnpause:
     """unpause() メソッドのテスト"""
 
     def test_unpause_sends_unpause_action(self, sut: EditorAPI, mock_conn: MagicMock) -> None:
+        """Send action='unpause' to resume the game."""
         mock_conn.send_request.return_value = {}
 
         sut.unpause()
@@ -74,6 +81,7 @@ class TestStop:
     """stop() メソッドのテスト"""
 
     def test_stop_sends_exit_action(self, sut: EditorAPI, mock_conn: MagicMock) -> None:
+        """Send action='exit' to exit play mode."""
         mock_conn.send_request.return_value = {}
 
         sut.stop()
@@ -86,6 +94,7 @@ class TestStep:
     """step() メソッドのテスト"""
 
     def test_step_sends_step_action(self, sut: EditorAPI, mock_conn: MagicMock) -> None:
+        """Send action='step' to advance one frame."""
         mock_conn.send_request.return_value = {}
 
         sut.step()
@@ -98,6 +107,7 @@ class TestGetState:
     """get_state() メソッドのテスト"""
 
     def test_get_state_sends_state_action(self, sut: EditorAPI, mock_conn: MagicMock) -> None:
+        """Send action='state' to retrieve editor state."""
         mock_conn.send_request.return_value = {}
 
         sut.get_state()
@@ -106,6 +116,7 @@ class TestGetState:
         assert params == {"action": "state"}
 
     def test_get_state_returns_response(self, sut: EditorAPI, mock_conn: MagicMock) -> None:
+        """Return the editor state response."""
         expected = {"isPlaying": False, "isPaused": False}
         mock_conn.send_request.return_value = expected
 
@@ -118,6 +129,7 @@ class TestGetTags:
     """get_tags() メソッドのテスト"""
 
     def test_get_tags_sends_get_tags_command(self, sut: EditorAPI, mock_conn: MagicMock) -> None:
+        """Send 'get_tags' as the command name."""
         mock_conn.send_request.return_value = {}
 
         sut.get_tags()
@@ -125,6 +137,7 @@ class TestGetTags:
         assert mock_conn.send_request.call_args[0][0] == "get_tags"
 
     def test_get_tags_sends_empty_params(self, sut: EditorAPI, mock_conn: MagicMock) -> None:
+        """Send empty params dict."""
         mock_conn.send_request.return_value = {}
 
         sut.get_tags()
@@ -137,6 +150,7 @@ class TestGetLayers:
     """get_layers() メソッドのテスト"""
 
     def test_get_layers_sends_get_layers_command(self, sut: EditorAPI, mock_conn: MagicMock) -> None:
+        """Send 'get_layers' as the command name."""
         mock_conn.send_request.return_value = {}
 
         sut.get_layers()
@@ -144,6 +158,7 @@ class TestGetLayers:
         assert mock_conn.send_request.call_args[0][0] == "get_layers"
 
     def test_get_layers_sends_empty_params(self, sut: EditorAPI, mock_conn: MagicMock) -> None:
+        """Send empty params dict."""
         mock_conn.send_request.return_value = {}
 
         sut.get_layers()
@@ -156,6 +171,7 @@ class TestRefresh:
     """refresh() メソッドのテスト"""
 
     def test_refresh_sends_refresh_command(self, sut: EditorAPI, mock_conn: MagicMock) -> None:
+        """Send 'refresh' as the command name."""
         mock_conn.send_request.return_value = {}
 
         sut.refresh()
@@ -163,6 +179,7 @@ class TestRefresh:
         assert mock_conn.send_request.call_args[0][0] == "refresh"
 
     def test_refresh_sends_empty_params(self, sut: EditorAPI, mock_conn: MagicMock) -> None:
+        """Send empty params dict."""
         mock_conn.send_request.return_value = {}
 
         sut.refresh()

--- a/tests/test_menu_api.py
+++ b/tests/test_menu_api.py
@@ -11,11 +11,13 @@ from unity_cli.api.menu import MenuAPI
 
 @pytest.fixture
 def mock_conn() -> MagicMock:
+    """Create a mock relay connection."""
     return MagicMock()
 
 
 @pytest.fixture
 def sut(mock_conn: MagicMock) -> MenuAPI:
+    """Create a MenuAPI instance with mock connection."""
     return MenuAPI(mock_conn)
 
 
@@ -23,6 +25,7 @@ class TestExecute:
     """execute() メソッドのテスト"""
 
     def test_execute_sends_menu_command(self, sut: MenuAPI, mock_conn: MagicMock) -> None:
+        """Send 'menu' as the command name."""
         mock_conn.send_request.return_value = {}
 
         sut.execute("Edit/Play")
@@ -30,6 +33,7 @@ class TestExecute:
         assert mock_conn.send_request.call_args[0][0] == "menu"
 
     def test_execute_sends_path(self, sut: MenuAPI, mock_conn: MagicMock) -> None:
+        """Send action='execute' with the menu path."""
         mock_conn.send_request.return_value = {}
 
         sut.execute("Window/General/Console")
@@ -38,6 +42,7 @@ class TestExecute:
         assert params == {"action": "execute", "path": "Window/General/Console"}
 
     def test_execute_returns_response(self, sut: MenuAPI, mock_conn: MagicMock) -> None:
+        """Return the execution result response."""
         expected = {"success": True, "path": "Edit/Play", "message": "Executed"}
         mock_conn.send_request.return_value = expected
 
@@ -50,6 +55,7 @@ class TestList:
     """list() メソッドのテスト"""
 
     def test_list_sends_list_action(self, sut: MenuAPI, mock_conn: MagicMock) -> None:
+        """Send action='list' to retrieve menu items."""
         mock_conn.send_request.return_value = {}
 
         sut.list()
@@ -58,6 +64,7 @@ class TestList:
         assert params["action"] == "list"
 
     def test_list_default_limit(self, sut: MenuAPI, mock_conn: MagicMock) -> None:
+        """Default limit is 100."""
         mock_conn.send_request.return_value = {}
 
         sut.list()
@@ -66,6 +73,7 @@ class TestList:
         assert params["limit"] == 100
 
     def test_list_with_custom_limit(self, sut: MenuAPI, mock_conn: MagicMock) -> None:
+        """Send custom limit value."""
         mock_conn.send_request.return_value = {}
 
         sut.list(limit=50)
@@ -74,6 +82,7 @@ class TestList:
         assert params["limit"] == 50
 
     def test_list_with_filter(self, sut: MenuAPI, mock_conn: MagicMock) -> None:
+        """Include filter key when filter_text is provided."""
         mock_conn.send_request.return_value = {}
 
         sut.list(filter_text="Window")
@@ -82,6 +91,7 @@ class TestList:
         assert params["filter"] == "Window"
 
     def test_list_without_filter_excludes_filter_key(self, sut: MenuAPI, mock_conn: MagicMock) -> None:
+        """Exclude filter key when filter_text is not provided."""
         mock_conn.send_request.return_value = {}
 
         sut.list()
@@ -94,6 +104,7 @@ class TestContext:
     """context() メソッドのテスト"""
 
     def test_context_sends_context_action(self, sut: MenuAPI, mock_conn: MagicMock) -> None:
+        """Send action='context' with the method name."""
         mock_conn.send_request.return_value = {}
 
         sut.context(method="Reset")
@@ -103,6 +114,7 @@ class TestContext:
         assert params["method"] == "Reset"
 
     def test_context_with_target(self, sut: MenuAPI, mock_conn: MagicMock) -> None:
+        """Include target key when target is provided."""
         mock_conn.send_request.return_value = {}
 
         sut.context(method="Reset", target="Main Camera")
@@ -111,6 +123,7 @@ class TestContext:
         assert params["target"] == "Main Camera"
 
     def test_context_without_target_excludes_target_key(self, sut: MenuAPI, mock_conn: MagicMock) -> None:
+        """Exclude target key when target is not provided."""
         mock_conn.send_request.return_value = {}
 
         sut.context(method="Reset")

--- a/tests/test_scene_api.py
+++ b/tests/test_scene_api.py
@@ -11,11 +11,13 @@ from unity_cli.api.scene import SceneAPI
 
 @pytest.fixture
 def mock_conn() -> MagicMock:
+    """Create a mock relay connection."""
     return MagicMock()
 
 
 @pytest.fixture
 def sut(mock_conn: MagicMock) -> SceneAPI:
+    """Create a SceneAPI instance with mock connection."""
     return SceneAPI(mock_conn)
 
 
@@ -23,6 +25,7 @@ class TestGetActive:
     """get_active() メソッドのテスト"""
 
     def test_get_active_sends_scene_command(self, sut: SceneAPI, mock_conn: MagicMock) -> None:
+        """Send 'scene' as the command name."""
         mock_conn.send_request.return_value = {}
 
         sut.get_active()
@@ -30,6 +33,7 @@ class TestGetActive:
         assert mock_conn.send_request.call_args[0][0] == "scene"
 
     def test_get_active_sends_active_action(self, sut: SceneAPI, mock_conn: MagicMock) -> None:
+        """Send action='active' to get active scene info."""
         mock_conn.send_request.return_value = {}
 
         sut.get_active()
@@ -38,6 +42,7 @@ class TestGetActive:
         assert params == {"action": "active"}
 
     def test_get_active_returns_response(self, sut: SceneAPI, mock_conn: MagicMock) -> None:
+        """Return the active scene response."""
         expected = {"name": "SampleScene", "path": "Assets/Scenes/SampleScene.unity"}
         mock_conn.send_request.return_value = expected
 
@@ -50,6 +55,7 @@ class TestGetHierarchy:
     """get_hierarchy() メソッドのテスト"""
 
     def test_get_hierarchy_sends_hierarchy_action(self, sut: SceneAPI, mock_conn: MagicMock) -> None:
+        """Send action='hierarchy' to get scene hierarchy."""
         mock_conn.send_request.return_value = {}
 
         sut.get_hierarchy()
@@ -58,6 +64,7 @@ class TestGetHierarchy:
         assert params["action"] == "hierarchy"
 
     def test_get_hierarchy_default_params(self, sut: SceneAPI, mock_conn: MagicMock) -> None:
+        """Default depth=1, page_size=50, cursor=0."""
         mock_conn.send_request.return_value = {}
 
         sut.get_hierarchy()
@@ -68,6 +75,7 @@ class TestGetHierarchy:
         assert params["cursor"] == 0
 
     def test_get_hierarchy_with_custom_depth(self, sut: SceneAPI, mock_conn: MagicMock) -> None:
+        """Send custom depth value."""
         mock_conn.send_request.return_value = {}
 
         sut.get_hierarchy(depth=3)
@@ -76,6 +84,7 @@ class TestGetHierarchy:
         assert params["depth"] == 3
 
     def test_get_hierarchy_with_pagination(self, sut: SceneAPI, mock_conn: MagicMock) -> None:
+        """Send custom page_size and cursor."""
         mock_conn.send_request.return_value = {}
 
         sut.get_hierarchy(page_size=20, cursor=5)
@@ -89,6 +98,7 @@ class TestLoad:
     """load() メソッドのテスト"""
 
     def test_load_sends_load_action(self, sut: SceneAPI, mock_conn: MagicMock) -> None:
+        """Send action='load' to load a scene."""
         mock_conn.send_request.return_value = {}
 
         sut.load(name="Main")
@@ -97,6 +107,7 @@ class TestLoad:
         assert params["action"] == "load"
 
     def test_load_by_name(self, sut: SceneAPI, mock_conn: MagicMock) -> None:
+        """Include name key when name is provided."""
         mock_conn.send_request.return_value = {}
 
         sut.load(name="Main")
@@ -105,6 +116,7 @@ class TestLoad:
         assert params["name"] == "Main"
 
     def test_load_by_path(self, sut: SceneAPI, mock_conn: MagicMock) -> None:
+        """Include path key when path is provided."""
         mock_conn.send_request.return_value = {}
 
         sut.load(path="Assets/Scenes/Main.unity")
@@ -113,6 +125,7 @@ class TestLoad:
         assert params["path"] == "Assets/Scenes/Main.unity"
 
     def test_load_additive(self, sut: SceneAPI, mock_conn: MagicMock) -> None:
+        """Set additive=True for additive scene loading."""
         mock_conn.send_request.return_value = {}
 
         sut.load(name="UI", additive=True)
@@ -121,6 +134,7 @@ class TestLoad:
         assert params["additive"] is True
 
     def test_load_default_not_additive(self, sut: SceneAPI, mock_conn: MagicMock) -> None:
+        """Default additive is False."""
         mock_conn.send_request.return_value = {}
 
         sut.load(name="Main")
@@ -129,6 +143,7 @@ class TestLoad:
         assert params["additive"] is False
 
     def test_load_without_name_excludes_name_key(self, sut: SceneAPI, mock_conn: MagicMock) -> None:
+        """Exclude name key when name is not provided."""
         mock_conn.send_request.return_value = {}
 
         sut.load(path="Assets/Scenes/Main.unity")
@@ -141,6 +156,7 @@ class TestSave:
     """save() メソッドのテスト"""
 
     def test_save_sends_save_action(self, sut: SceneAPI, mock_conn: MagicMock) -> None:
+        """Send action='save' to save current scene."""
         mock_conn.send_request.return_value = {}
 
         sut.save()
@@ -149,6 +165,7 @@ class TestSave:
         assert params["action"] == "save"
 
     def test_save_with_path(self, sut: SceneAPI, mock_conn: MagicMock) -> None:
+        """Include path key when save path is provided."""
         mock_conn.send_request.return_value = {}
 
         sut.save(path="Assets/Scenes/NewScene.unity")
@@ -157,6 +174,7 @@ class TestSave:
         assert params["path"] == "Assets/Scenes/NewScene.unity"
 
     def test_save_without_path_excludes_path_key(self, sut: SceneAPI, mock_conn: MagicMock) -> None:
+        """Exclude path key when path is not provided."""
         mock_conn.send_request.return_value = {}
 
         sut.save()

--- a/tests/test_selection_api.py
+++ b/tests/test_selection_api.py
@@ -11,11 +11,13 @@ from unity_cli.api.selection import SelectionAPI
 
 @pytest.fixture
 def mock_conn() -> MagicMock:
+    """Create a mock relay connection."""
     return MagicMock()
 
 
 @pytest.fixture
 def sut(mock_conn: MagicMock) -> SelectionAPI:
+    """Create a SelectionAPI instance with mock connection."""
     return SelectionAPI(mock_conn)
 
 
@@ -23,6 +25,7 @@ class TestGet:
     """get() メソッドのテスト"""
 
     def test_get_sends_selection_command(self, sut: SelectionAPI, mock_conn: MagicMock) -> None:
+        """Send 'selection' as the command name."""
         mock_conn.send_request.return_value = {}
 
         sut.get()
@@ -30,6 +33,7 @@ class TestGet:
         assert mock_conn.send_request.call_args[0][0] == "selection"
 
     def test_get_sends_get_action(self, sut: SelectionAPI, mock_conn: MagicMock) -> None:
+        """Send action='get' to retrieve current selection."""
         mock_conn.send_request.return_value = {}
 
         sut.get()
@@ -38,6 +42,7 @@ class TestGet:
         assert params == {"action": "get"}
 
     def test_get_returns_response(self, sut: SelectionAPI, mock_conn: MagicMock) -> None:
+        """Return the selection response including objects and GUIDs."""
         expected = {
             "count": 1,
             "activeObject": {"name": "Main Camera", "type": "Camera", "instanceID": 100},

--- a/tests/test_tests_api.py
+++ b/tests/test_tests_api.py
@@ -11,11 +11,13 @@ from unity_cli.api.tests import TestAPI
 
 @pytest.fixture
 def mock_conn() -> MagicMock:
+    """Create a mock relay connection."""
     return MagicMock()
 
 
 @pytest.fixture
 def sut(mock_conn: MagicMock) -> TestAPI:
+    """Create a TestAPI instance with mock connection."""
     return TestAPI(mock_conn)
 
 
@@ -23,6 +25,7 @@ class TestRun:
     """run() メソッドのテスト"""
 
     def test_run_sends_tests_command(self, sut: TestAPI, mock_conn: MagicMock) -> None:
+        """Send 'tests' as the command name."""
         mock_conn.send_request.return_value = {}
 
         sut.run()
@@ -30,6 +33,7 @@ class TestRun:
         assert mock_conn.send_request.call_args[0][0] == "tests"
 
     def test_run_sends_run_action(self, sut: TestAPI, mock_conn: MagicMock) -> None:
+        """Send action='run' to execute tests."""
         mock_conn.send_request.return_value = {}
 
         sut.run()
@@ -38,6 +42,7 @@ class TestRun:
         assert params["action"] == "run"
 
     def test_run_default_mode_is_edit(self, sut: TestAPI, mock_conn: MagicMock) -> None:
+        """Default mode is 'edit'."""
         mock_conn.send_request.return_value = {}
 
         sut.run()
@@ -46,6 +51,7 @@ class TestRun:
         assert params["mode"] == "edit"
 
     def test_run_with_play_mode(self, sut: TestAPI, mock_conn: MagicMock) -> None:
+        """Send mode='play' when specified."""
         mock_conn.send_request.return_value = {}
 
         sut.run(mode="play")
@@ -54,6 +60,7 @@ class TestRun:
         assert params["mode"] == "play"
 
     def test_run_with_test_names(self, sut: TestAPI, mock_conn: MagicMock) -> None:
+        """Include testNames key when test_names is provided."""
         mock_conn.send_request.return_value = {}
 
         sut.run(test_names=["MyTests.TestA", "MyTests.TestB"])
@@ -62,6 +69,7 @@ class TestRun:
         assert params["testNames"] == ["MyTests.TestA", "MyTests.TestB"]
 
     def test_run_with_categories(self, sut: TestAPI, mock_conn: MagicMock) -> None:
+        """Include categories key when categories is provided."""
         mock_conn.send_request.return_value = {}
 
         sut.run(categories=["Unit", "Integration"])
@@ -70,6 +78,7 @@ class TestRun:
         assert params["categories"] == ["Unit", "Integration"]
 
     def test_run_with_assemblies(self, sut: TestAPI, mock_conn: MagicMock) -> None:
+        """Include assemblies key when assemblies is provided."""
         mock_conn.send_request.return_value = {}
 
         sut.run(assemblies=["Tests.EditMode"])
@@ -78,6 +87,7 @@ class TestRun:
         assert params["assemblies"] == ["Tests.EditMode"]
 
     def test_run_with_group_pattern(self, sut: TestAPI, mock_conn: MagicMock) -> None:
+        """Include groupPattern key when group_pattern is provided."""
         mock_conn.send_request.return_value = {}
 
         sut.run(group_pattern=".*Integration.*")
@@ -86,6 +96,7 @@ class TestRun:
         assert params["groupPattern"] == ".*Integration.*"
 
     def test_run_without_optional_params_excludes_keys(self, sut: TestAPI, mock_conn: MagicMock) -> None:
+        """Exclude optional keys when not provided."""
         mock_conn.send_request.return_value = {}
 
         sut.run()
@@ -98,6 +109,7 @@ class TestList:
     """list() メソッドのテスト"""
 
     def test_list_sends_list_action(self, sut: TestAPI, mock_conn: MagicMock) -> None:
+        """Send action='list' to list available tests."""
         mock_conn.send_request.return_value = {}
 
         sut.list()
@@ -106,6 +118,7 @@ class TestList:
         assert params["action"] == "list"
 
     def test_list_default_mode_is_edit(self, sut: TestAPI, mock_conn: MagicMock) -> None:
+        """Default mode is 'edit'."""
         mock_conn.send_request.return_value = {}
 
         sut.list()
@@ -114,6 +127,7 @@ class TestList:
         assert params == {"action": "list", "mode": "edit"}
 
     def test_list_with_play_mode(self, sut: TestAPI, mock_conn: MagicMock) -> None:
+        """Send mode='play' when specified."""
         mock_conn.send_request.return_value = {}
 
         sut.list(mode="play")
@@ -126,6 +140,7 @@ class TestStatus:
     """status() メソッドのテスト"""
 
     def test_status_sends_status_action(self, sut: TestAPI, mock_conn: MagicMock) -> None:
+        """Send action='status' to check test run status."""
         mock_conn.send_request.return_value = {}
 
         sut.status()
@@ -134,6 +149,7 @@ class TestStatus:
         assert params == {"action": "status"}
 
     def test_status_returns_response(self, sut: TestAPI, mock_conn: MagicMock) -> None:
+        """Return the test status response."""
         expected = {"running": True, "passed": 5, "failed": 1}
         mock_conn.send_request.return_value = expected
 


### PR DESCRIPTION
## Summary

- EditorAPI, SelectionAPI, MenuAPI, ConsoleAPI, SceneAPI, TestAPI の6モジュール22メソッドに対するユニットテストを追加
- 既存テストパターン (`mock_conn` + `sut` fixture) を踏襲
- 67件のテストケースを追加 (全236テスト pass)

## Test plan

- [x] `uv run pytest tests/ -v` で全テスト通過を確認
- [x] pre-commit hooks (ruff, ruff-format) 通過

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * コンソール、エディタ、メニュー、シーン、選択、テスト関連のCLI APIに対する単体テストを追加・拡充。
  * 各APIのコマンド送信、アクション／パラメータの組み立て、オプション項目の有無、既定値、戻り値の透過を検証。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->