### PR TITLE
GameViewスクリーンショットにPlay Modeチェックを追加

### DIFF
--- a/UnityBridge/Editor/Tools/Screenshot.cs
+++ b/UnityBridge/Editor/Tools/Screenshot.cs
@@ -61,6 +61,13 @@ namespace UnityBridge.Tools
 
         private static Task<JObject> CaptureGameViewAsync(string path, int superSize)
         {
+            if (!EditorApplication.isPlaying)
+            {
+                throw new ProtocolException(
+                    ErrorCode.InvalidParams,
+                    "GameView screenshot requires Play Mode. Enter Play Mode first with 'manage_editor play' command.");
+            }
+
             superSize = Mathf.Clamp(superSize, 1, 4);
 
             if (GameViewType == null)


### PR DESCRIPTION
## Summary

- Play Mode 外で `screenshot -s game` 実行時に明確なエラーを返すようにした
- `CaptureGameViewAsync` 冒頭で `EditorApplication.isPlaying` チェックを追加
- `scene` / `camera` ソースは Play Mode 不要のため変更なし

Closes #29

## Test plan

- [ ] Play Mode 外で `u screenshot -s game` → `InvalidParams` エラーが返ること
- [ ] Play Mode 中で `u screenshot -s game` → 正常にキャプチャされること
- [ ] `u screenshot -s scene` が Play Mode 外でも動作すること

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **バグ修正**
  * GameViewスクリーンショット撮影時にPlayMode有効状態の検証を追加しました。PlayModeが無効な場合は適切なエラーメッセージが表示されるようになります。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->