### PR TITLE
EditorWindow の Host/Port 設定を永続化

### DIFF
--- a/UnityBridge/Editor/BridgeEditorWindow.cs
+++ b/UnityBridge/Editor/BridgeEditorWindow.cs
@@ -9,6 +9,9 @@ namespace UnityBridge
     /// </summary>
     public class BridgeEditorWindow : EditorWindow
     {
+        private const string EditorPrefsKeyHost = "UnityBridge.Connection.Host";
+        private const string EditorPrefsKeyPort = "UnityBridge.Connection.Port";
+
         private string _host = "127.0.0.1";
         private int _port = ProtocolConstants.DefaultPort;
         private Vector2 _scrollPosition;
@@ -35,6 +38,12 @@ namespace UnityBridge
 
         private void OnEnable()
         {
+            _host = EditorPrefs.GetString(EditorPrefsKeyHost, "127.0.0.1");
+            _port = Mathf.Clamp(
+                EditorPrefs.GetInt(EditorPrefsKeyPort, ProtocolConstants.DefaultPort),
+                1,
+                65535);
+
             RelayServerLauncher.Instance.ServerStarted += OnServerStateChanged;
             RelayServerLauncher.Instance.ServerStopped += OnServerStateChanged;
             EditorApplication.update += PollConnectionStatus;
@@ -199,13 +208,23 @@ namespace UnityBridge
             using (new EditorGUILayout.HorizontalScope())
             {
                 EditorGUILayout.LabelField("Host:", GUILayout.Width(40));
-                _host = EditorGUILayout.TextField(_host);
+                var newHost = EditorGUILayout.TextField(_host);
+                if (newHost != _host)
+                {
+                    _host = newHost.Trim();
+                    EditorPrefs.SetString(EditorPrefsKeyHost, _host);
+                }
             }
 
             using (new EditorGUILayout.HorizontalScope())
             {
                 EditorGUILayout.LabelField("Port:", GUILayout.Width(40));
-                _port = EditorGUILayout.IntField(_port);
+                var newPort = Mathf.Clamp(EditorGUILayout.IntField(_port), 1, 65535);
+                if (newPort != _port)
+                {
+                    _port = newPort;
+                    EditorPrefs.SetInt(EditorPrefsKeyPort, _port);
+                }
             }
 
             EditorGUILayout.Space(5);


### PR DESCRIPTION
## Summary

- BridgeEditorWindow の Host/Port 設定を EditorPrefs で永続化
- ウィンドウを閉じても接続設定が維持される
- UI 変更時にリアルタイム保存

## Test plan

- [ ] Unity Editor で Window > Unity Bridge を開く
- [ ] Host を別の値（例: `192.168.1.100`）に変更
- [ ] Port を別の値（例: `7000`）に変更
- [ ] ウィンドウを閉じる
- [ ] 再度 Window > Unity Bridge を開く
- [ ] Host と Port が変更した値のままであることを確認

Closes #32

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## リリースノート

* **改善**
  * 接続設定（ホスト・ポート）がエディター再起動時に保持されるようになりました。
  * ポート入力の検証が強化され、有効な範囲（1～65535）に自動調整されます。
  * ホスト入力の前後の空白が自動的に削除されるようになりました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->