### PR TITLE
🎨 str+Enum を StrEnum に置換 (ruff UP042)

### DIFF
--- a/relay/protocol.py
+++ b/relay/protocol.py
@@ -11,7 +11,7 @@ import json
 import struct
 import time
 import uuid
-from enum import Enum
+from enum import StrEnum
 from typing import Any, Literal
 
 from pydantic import BaseModel, ConfigDict, Field, field_validator
@@ -22,7 +22,7 @@ MAX_PAYLOAD_BYTES = 16 * 1024 * 1024  # 16 MiB
 HEADER_SIZE = 4
 
 
-class MessageType(str, Enum):
+class MessageType(StrEnum):
     # Unity -> Relay
     REGISTER = "REGISTER"
     REGISTERED = "REGISTERED"
@@ -45,7 +45,7 @@ class MessageType(str, Enum):
     INSTANCES = "INSTANCES"
 
 
-class ErrorCode(str, Enum):
+class ErrorCode(StrEnum):
     INSTANCE_NOT_FOUND = "INSTANCE_NOT_FOUND"
     INSTANCE_RELOADING = "INSTANCE_RELOADING"
     INSTANCE_BUSY = "INSTANCE_BUSY"
@@ -63,7 +63,7 @@ class ErrorCode(str, Enum):
     AMBIGUOUS_INSTANCE = "AMBIGUOUS_INSTANCE"
 
 
-class InstanceStatus(str, Enum):
+class InstanceStatus(StrEnum):
     READY = "ready"
     BUSY = "busy"
     RELOADING = "reloading"


### PR DESCRIPTION
## Summary
- `relay/protocol.py` の `MessageType`, `ErrorCode`, `InstanceStatus` を `(str, Enum)` から `StrEnum` に変更
- ruff UP042 の lint エラーを解消

## Test plan
- [x] `ruff check` パス
- [x] `pytest` 253件パス

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **リファクタリング**
  * 内部型定義の構造を更新しました。ユーザーに対する可視的な変更はありません。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->