### PR TITLE
🐛 fix: BridgeToolbar の UQueryBuilder API 互換性修正

### DIFF
--- a/UnityBridge/Editor/BridgeToolbar.cs
+++ b/UnityBridge/Editor/BridgeToolbar.cs
@@ -195,7 +195,7 @@ namespace UnityBridge
 
             // Unity 6000.3+: find the main toolbar container
             var overlayContainer = root.Query<VisualElement>()
-                .Where(e => e.GetType().Name == "MainToolbarOverlayContainer").FirstOrDefault();
+                .Where(e => e.GetType().Name == "MainToolbarOverlayContainer").First();
 
             // Find the right-most ContainerSection (after Account/Services)
             VisualElement rightZone = null;


### PR DESCRIPTION
## Summary
- `BridgeToolbar.cs:198` で `UQueryBuilder<VisualElement>` に存在しない LINQ の `FirstOrDefault()` を呼んでいたコンパイルエラーを修正
- UIElements ネイティブの `First()` に置換（要素未発見時は `null` を返す）

## Test plan
- [ ] Unity Editor でコンパイルエラーが解消されることを確認
- [ ] ツールバーに Bridge ボタンが表示されることを確認

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **バグ修正**
  * Unityメインツールバーの初期化処理を改善し、エラーハンドリングを強化しました。ツールバー要素の検出がより堅牢になり、初期化時の信頼性が向上します。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->