### PR TITLE
fix: log_types デフォルト値統一 & バージョン比較フォールバック修正

### DIFF
--- a/unity_cli/config.py
+++ b/unity_cli/config.py
@@ -28,6 +28,7 @@ CONFIG_FILE_NAME = ".unity-cli.toml"
 
 # Valid log types for validation
 VALID_LOG_TYPES = frozenset({"log", "warning", "error", "assert", "exception"})
+_DEFAULT_LOG_TYPES = ["log", "warning", "error"]
 
 
 # =============================================================================
@@ -67,7 +68,7 @@ class UnityCLIConfig(BaseModel):
     timeout: Annotated[float, Field(gt=0)] = 15.0
     timeout_ms: Annotated[int, Field(gt=0)] = DEFAULT_TIMEOUT_MS
     instance: str | None = None
-    log_types: list[str] = Field(default_factory=lambda: ["log", "warning", "error"])
+    log_types: list[str] = Field(default_factory=lambda: list(_DEFAULT_LOG_TYPES))
     log_count: Annotated[int, Field(gt=0)] = 20
     retry_initial_ms: Annotated[int, Field(gt=0)] = 500
     retry_max_ms: Annotated[int, Field(gt=0)] = 8000
@@ -78,7 +79,7 @@ class UnityCLIConfig(BaseModel):
     def validate_log_types(cls, v: Any) -> list[str]:
         """Validate that log_types contains only valid types."""
         if v is None:
-            return ["error", "warning"]
+            return list(_DEFAULT_LOG_TYPES)
 
         if isinstance(v, str):
             v = [v]

--- a/unity_cli/update_checker.py
+++ b/unity_cli/update_checker.py
@@ -1,0 +1,79 @@
+"""Check for CLI updates via GitHub Releases API."""
+
+from __future__ import annotations
+
+import json
+import os
+import threading
+import time
+from pathlib import Path
+from urllib.error import URLError
+from urllib.request import Request, urlopen
+
+CACHE_DIR = Path(os.environ.get("XDG_CACHE_HOME", Path.home() / ".cache")) / "unity-cli"
+CACHE_FILE = CACHE_DIR / "update-check.json"
+CHECK_INTERVAL = 86400  # 24 hours
+RELEASES_URL = "https://api.github.com/repos/bigdra50/unity-cli/releases/latest"
+FETCH_TIMEOUT = 3  # seconds
+
+
+def get_latest_version_cached() -> str | None:
+    """Return cached latest version if TTL is still valid, else None."""
+    try:
+        if not CACHE_FILE.exists():
+            return None
+        data = json.loads(CACHE_FILE.read_text())
+        if time.time() - data.get("checked_at", 0) > CHECK_INTERVAL:
+            return None
+        version: str | None = data.get("latest_version")
+        return version
+    except (json.JSONDecodeError, OSError):
+        return None
+
+
+def _fetch_latest_version() -> None:
+    """Fetch latest version from GitHub API and write to cache (blocking)."""
+    try:
+        req = Request(RELEASES_URL, headers={"Accept": "application/vnd.github.v3+json"})
+        with urlopen(req, timeout=FETCH_TIMEOUT) as resp:
+            data = json.loads(resp.read().decode("utf-8"))
+        tag = data.get("tag_name", "")
+        version = tag.lstrip("v")
+        if not version:
+            return
+        CACHE_DIR.mkdir(parents=True, exist_ok=True)
+        CACHE_FILE.write_text(json.dumps({"latest_version": version, "checked_at": time.time()}))
+    except (URLError, OSError, json.JSONDecodeError, KeyError):
+        pass
+
+
+def start_update_check() -> None:
+    """Start background check for updates (daemon thread, non-blocking)."""
+    cached = get_latest_version_cached()
+    if cached is not None:
+        return
+    t = threading.Thread(target=_fetch_latest_version, daemon=True)
+    t.start()
+
+
+def get_update_message(current: str) -> str | None:
+    """Return an update notification message if a newer version exists."""
+    latest = get_latest_version_cached()
+    if not latest or not current:
+        return None
+    try:
+        from packaging.version import Version
+
+        if Version(latest) > Version(current):
+            return f"Update available: {current} -> {latest}\nRun 'uv tool install --force unity-cli' to update"
+    except ImportError:
+        # packaging not available; fall back to tuple comparison
+        def _parse_version(v: str) -> tuple[int, ...]:
+            return tuple(int(x) for x in v.split("."))
+
+        try:
+            if _parse_version(latest) > _parse_version(current):
+                return f"Update available: {current} -> {latest}\nRun 'uv tool install --force unity-cli' to update"
+        except (ValueError, TypeError):
+            pass
+    return None


### PR DESCRIPTION
## Summary
- `config.py`: フィールドデフォルトとバリデータの None パスで `log_types` の値が不一致だった問題を `_DEFAULT_LOG_TYPES` 定数で統一
- `update_checker.py`: `packaging` 未インストール時のフォールバックが辞書順比較で誤動作する問題をタプル比較に修正

Closes #47
Closes #46

## Test plan
- [ ] `uv run python -m pytest tests/ -x` が全件パスすること
- [ ] 設定ファイルなし / `log_types: null` の両ケースで同じデフォルト値が返ること
- [ ] `"3.10.0"` vs `"3.6.0"` のようなバージョン比較が正しく動作すること