### PR TITLE
fix: Scene hierarchy のページネーションカーソル計算を修正

### DIFF
--- a/UnityBridge/Editor/Tools/Scene.cs
+++ b/UnityBridge/Editor/Tools/Scene.cs
@@ -79,14 +79,13 @@ namespace UnityBridge.Tools
                 currentIndex++;
             }
 
-            var hasMore = currentIndex < totalRootCount || collected >= pageSize;
-            var nextCursor = hasMore ? cursor + collected : -1;
+            var hasMore = currentIndex < totalRootCount;
 
             return new JObject
             {
                 ["items"] = JArray.FromObject(items),
-                ["hasMore"] = hasMore && nextCursor < totalRootCount,
-                ["nextCursor"] = nextCursor >= totalRootCount ? -1 : nextCursor,
+                ["hasMore"] = hasMore,
+                ["nextCursor"] = hasMore ? currentIndex : -1,
                 ["totalRootCount"] = totalRootCount
             };
         }


### PR DESCRIPTION
## Summary
- `nextCursor` の計算に `collected`(子要素込みの全収集数)を使っていたため、`depth > 0` で子要素を含む場合にルートオブジェクトがスキップされる問題を修正
- `currentIndex`(次に処理すべきルートのインデックス)を使うよう変更

Closes #45

## Test plan
- [ ] ルート10個 × 子2個、`pageSize=5, depth=1` で2ページ目が root2 から始まること
- [ ] `depth=0`(子なし)の場合は従来通り動作すること
- [ ] `hasMore` / `nextCursor` が `totalRootCount` を超えないこと

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **改善**
  * シーン階層の読み込みロジックを最適化し、ページング処理を改善しました。カーソル追跡と残り項目の判定がより効率的に動作するようになります。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->