### PR TITLE
fix: UITree の ref ID をエポックベースに変更しドメインリロード耐性を確保

### DIFF
--- a/UnityBridge/Editor/Protocol.cs
+++ b/UnityBridge/Editor/Protocol.cs
@@ -72,6 +72,7 @@ namespace UnityBridge
         public const string ProtocolVersionMismatch = "PROTOCOL_VERSION_MISMATCH";
         public const string CapabilityNotSupported = "CAPABILITY_NOT_SUPPORTED";
         public const string QueueFull = "QUEUE_FULL";
+        public const string StaleRef = "STALE_REF";
     }
 
     /// <summary>
@@ -245,10 +246,18 @@ namespace UnityBridge
                 ["instance_id"] = instanceId,
                 ["project_name"] = projectName,
                 ["unity_version"] = unityVersion,
+                ["bridge_version"] = GetBridgeVersion(),
                 ["capabilities"] = new JArray(capabilities ?? Array.Empty<string>()),
                 ["ts"] = GetTimestamp()
             };
             return msg;
+        }
+
+        private static string GetBridgeVersion()
+        {
+            var info = UnityEditor.PackageManager.PackageInfo
+                .FindForAssembly(typeof(ProtocolConstants).Assembly);
+            return info?.version ?? "unknown";
         }
 
         /// <summary>

--- a/relay/protocol.py
+++ b/relay/protocol.py
@@ -60,6 +60,7 @@ class ErrorCode(StrEnum):
     PROTOCOL_VERSION_MISMATCH = "PROTOCOL_VERSION_MISMATCH"
     CAPABILITY_NOT_SUPPORTED = "CAPABILITY_NOT_SUPPORTED"
     QUEUE_FULL = "QUEUE_FULL"
+    STALE_REF = "STALE_REF"
     AMBIGUOUS_INSTANCE = "AMBIGUOUS_INSTANCE"
 
 
@@ -105,6 +106,7 @@ class RegisterMessage(Message):
     instance_id: str = ""
     project_name: str = ""
     unity_version: str = ""
+    bridge_version: str = ""
     capabilities: list[str] = Field(default_factory=list)
 
     @field_validator("instance_id")
@@ -249,6 +251,8 @@ class ResponseMessage(Message):
     success: bool = True
     data: dict[str, Any] | None = None
     error: dict[str, str] | None = None
+    relay_version: str = ""
+    bridge_version: str = ""
 
 
 class ErrorMessage(Message):


### PR DESCRIPTION
## Summary
- ref ID 形式を `ref_{epoch}_{seq}` に変更し、ドメインリロード後のID衝突を構造的に防止
- `SessionState` でエポックを永続化、`[InitializeOnLoadMethod]` でリロードごとにインクリメント
- `ResolveRef` に epoch バリデーション + `panel == null` チェックを追加
- `STALE_REF` エラーコードを C# / Python 両側に追加

Closes #44

## Test plan
- [ ] `u uitree dump` で `ref_{N}_{seq}` 形式の ID が返ること
- [ ] スクリプト変更でドメインリロード後、旧 ref で `u uitree inspect` すると `STALE_REF` エラーが返ること
- [ ] リロード後に再度 `u uitree dump` すると新しいエポックの ref が取得できること
- [ ] GC された要素の ref は `"ref not found or element has been garbage collected"` を返すこと