### PR TITLE
プレーンテキスト出力をデフォルトにし、パイプ互換性を確保

### DIFF
--- a/unity_cli/cli/output.py
+++ b/unity_cli/cli/output.py
@@ -6,7 +6,7 @@ Supports three modes:
   - JSON: Machine-readable JSON
 
 Mode resolution priority:
-  per-command --json > UNITY_CLI_JSON > --pretty/--no-pretty > UNITY_CLI_NO_PRETTY/NO_COLOR > isatty()
+  per-command --json > --pretty/--no-pretty > UNITY_CLI_JSON > UNITY_CLI_NO_PRETTY/NO_COLOR > isatty()
 """
 
 from __future__ import annotations
@@ -14,7 +14,6 @@ from __future__ import annotations
 import enum
 import json
 import os
-import re
 import sys
 from dataclasses import dataclass
 from typing import Any
@@ -128,13 +127,15 @@ def get_err_console() -> Console:
 # Plain-text helpers
 # =============================================================================
 
-_RICH_MARKUP_RE = re.compile(r"\[/?[a-zA-Z][^\]]*\]")
-
 
 def print_line(text: str) -> None:
-    """Print a line, stripping Rich markup in non-PRETTY mode."""
+    """Print a line, stripping Rich markup in non-PRETTY mode.
+
+    Uses Rich's own markup parser to avoid stripping legitimate bracket
+    content like ``[ERROR]`` or ``[Physics]`` from server data.
+    """
     if console.no_color:
-        print(_RICH_MARKUP_RE.sub("", text))
+        print(Text.from_markup(text).plain)
     else:
         console.print(text)
 


### PR DESCRIPTION
## Summary

- パイプ時にANSIエスケープが混入し `grep`/`awk`/`cut` と合成できない問題を解決
- `OutputMode` (PRETTY/PLAIN/JSON) と `resolve_output_mode()` で出力モードを一元管理
- `--json` をper-commandオプションに変更（`u state --json` のように使用）
- グローバル `--pretty` / `--no-pretty` フラグは維持

### 出力モード解決優先順位

per-command `--json` > `UNITY_CLI_JSON` env > `--pretty`/`--no-pretty` > `UNITY_CLI_NO_PRETTY`/`NO_COLOR` > `isatty()`

### 変更ファイル

| ファイル | 変更内容 |
|----------|----------|
| `unity_cli/cli/output.py` | OutputMode/OutputConfig追加、resolve_output_mode()、configure_output()、print_line()、全ヘルパーにplain分岐 |
| `unity_cli/cli/app.py` | 33コマンドの hidden `--output-format` を公開 `--json` フラグに置換、グローバル `--json` 削除 |
| `tests/test_output.py` | resolve_output_mode/OutputConfig/plain出力テスト |

## Test plan

- [x] 300ユニットテスト全パス
- [ ] `u state | cat` でANSIエスケープが混入しないこと
- [ ] `u state --json | jq .status` でJSON合成できること
- [ ] `u instances | cut -f2` でTSVカラム抽出できること
- [ ] `u --no-pretty instances` で強制プレーン出力になること
- [ ] `UNITY_CLI_JSON=1 u state` で環境変数経由JSON出力
- [ ] `NO_COLOR=1 u state` でNO_COLOR規約対応

Closes #53

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * CLI全体で切替可能な3つの出力モード（プリティ／プレーン／JSON）を導入
  * 各コマンドでのJSONフラグ対応と自動判定（環境変数・TTY検出）により出力形式を一貫して選択可能
  * プレーン表示での整形出力とANSI装飾無効化を提供

* **改善**
  * 出力経路を統一し、各コマンドの表示がモードに応じて一貫して動作するように調整

* **テスト**
  * 出力モードとプレーン出力の挙動を網羅するテストを追加
<!-- end of auto-generated comment: release notes by coderabbit.ai -->