### PR TITLE
import-linterで依存構造を宣言的に強制

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,6 +45,25 @@ jobs:
             uvx ruff format --check $DIRS
           fi
 
+  architecture:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v4
+
+      - name: Install dependencies
+        run: uv sync
+
+      - name: Run import-linter
+        run: uv run lint-imports
+
   type-check:
     runs-on: ubuntu-latest
     steps:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -24,3 +24,12 @@ repos:
       - id: end-of-file-fixer
       - id: check-yaml
       - id: check-added-large-files
+
+  - repo: local
+    hooks:
+      - id: import-linter
+        name: import-linter
+        entry: uv run lint-imports
+        language: system
+        pass_filenames: false
+        types: [python]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,6 +37,7 @@ dev = [
     "mypy>=1.19.1",
     "ruff>=0.14.13",
     "pre-commit>=4.0",
+    "import-linter>=2.1",
 ]
 
 [tool.pytest.ini_options]
@@ -102,3 +103,34 @@ strict = true
 warn_return_any = true
 warn_unused_configs = true
 disallow_untyped_defs = true
+
+[tool.importlinter]
+root_packages = ["relay", "unity_cli"]
+
+[[tool.importlinter.contracts]]
+name = "relay and unity_cli are independent"
+type = "independence"
+modules = ["relay", "unity_cli"]
+
+[[tool.importlinter.contracts]]
+name = "unity_cli layer ordering"
+type = "layers"
+layers = [
+    "unity_cli.cli",
+    "unity_cli.hub | unity_cli.api | unity_cli.client",
+    "unity_cli.models | unity_cli.config | unity_cli.exceptions",
+]
+# client <-> api は TYPE_CHECKING + 遅延importによる意図的な相互参照
+ignore_imports = [
+    "unity_cli.client -> unity_cli.api",
+    "unity_cli.api.* -> unity_cli.client",
+]
+
+[[tool.importlinter.contracts]]
+name = "relay layer ordering"
+type = "layers"
+layers = [
+    "relay.server",
+    "relay.instance_registry | relay.request_cache",
+    "relay.status_file | relay.protocol",
+]


### PR DESCRIPTION
## Summary

- `relay/` と `unity_cli/` の相互独立性、各パッケージ内部のレイヤー構造を import-linter のコントラクトで宣言的に定義
- CI・pre-commit で依存ルール違反を自動検出し、意図しない依存混入を防止

## Changes

| ファイル | 変更内容 |
|---------|---------|
| `pyproject.toml` | dev依存に `import-linter>=2.1` 追加、3つのコントラクト定義 |
| `.pre-commit-config.yaml` | `uv run lint-imports` フック追加 |
| `.github/workflows/ci.yml` | `architecture` ジョブ追加 |

### コントラクト

1. `independence` — `relay` と `unity_cli` の相互依存を禁止
2. `layers` (unity_cli) — `cli` → `hub|api|client` → `models|config|exceptions`
3. `layers` (relay) — `server` → `instance_registry|request_cache` → `status_file|protocol`

## Test plan

- [x] `uv run lint-imports` で 3 contracts KEPT を確認
- [x] `uv run pre-commit run import-linter --all-files` で Passed を確認
- [ ] CI の `architecture` ジョブが通ることを確認

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Chores**
  * コード構造を自動検証するツールを導入しました。継続的インテグレーションと開発環境に統合され、プロジェクトのアーキテクチャルールへの準拠を保証します。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->