### PR TITLE
UnityBridge: インターフェース抽出・DI対応・スレッド安全性・DRY改善

### DIFF
--- a/TestProject/Assets/Tests/Editor/BridgeJobStateStoreTests.cs
+++ b/TestProject/Assets/Tests/Editor/BridgeJobStateStoreTests.cs
@@ -1,0 +1,169 @@
+using System;
+using System.IO;
+using Newtonsoft.Json;
+using NUnit.Framework;
+using UnityBridge.Helpers;
+
+namespace Game.Tests.Editor
+{
+    /// <summary>
+    /// BridgeJobStateStore の空 catch 問題を検証するテスト。
+    /// LoadState の catch (Exception) { return default; } により、
+    /// JSON破損時にエラー情報が呼び出し元に伝わらない。
+    /// </summary>
+    [TestFixture]
+    public class BridgeJobStateStoreTests
+    {
+        private const string TestToolName = "BridgeJobStateStoreTest";
+
+        [Serializable]
+        private class SampleState
+        {
+            public string Name;
+            public int Value;
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            BridgeJobStateStore.ClearState(TestToolName);
+        }
+
+        /// <summary>
+        /// 正常なJSONの保存と読み込みが往復できることを確認する基本テスト。
+        /// </summary>
+        [Test]
+        public void SaveAndLoadState_ValidData_RoundTrips()
+        {
+            var original = new SampleState { Name = "test", Value = 42 };
+
+            BridgeJobStateStore.SaveState(TestToolName, original);
+            var loaded = BridgeJobStateStore.LoadState<SampleState>(TestToolName);
+
+            Assert.That(loaded, Is.Not.Null);
+            Assert.That(loaded.Name, Is.EqualTo("test"));
+            Assert.That(loaded.Value, Is.EqualTo(42));
+        }
+
+        /// <summary>
+        /// ファイルが存在しない場合、LoadState は default を返す。
+        /// これは正常な動作。
+        /// </summary>
+        [Test]
+        public void LoadState_FileNotExists_ReturnsDefault()
+        {
+            var result = BridgeJobStateStore.LoadState<SampleState>("nonexistent-tool-xyz");
+
+            Assert.That(result, Is.Null);
+        }
+
+        /// <summary>
+        /// 不正なJSONが書き込まれた場合、LoadState が default を返す。
+        /// 問題: ファイル未存在と不正JSONの区別がつかない。
+        /// 呼び出し元は「状態がない」と「状態が破損している」を区別できない。
+        ///
+        /// このテストは、空catchにより例外情報が失われることを明示する。
+        /// 現状のコードではこのテストは PASS するが、それ自体が問題を示している。
+        /// </summary>
+        [Test]
+        public void LoadState_CorruptedJson_ReturnsDefaultSilently()
+        {
+            // まず正常な状態を保存して、ファイルパスを確定させる
+            BridgeJobStateStore.SaveState(TestToolName, new SampleState { Name = "valid", Value = 1 });
+            Assert.That(BridgeJobStateStore.HasState(TestToolName), Is.True,
+                "前提条件: ファイルが存在すること");
+
+            // ファイルを壊す: 保存後に不正JSONで上書き
+            // GetStatePath は internal なので、SaveState で作られたファイルの場所を推定する
+            // Library/UnityBridgeState_{toolName}.json のパス
+            var libraryPath = Path.Combine(UnityEngine.Application.dataPath, "..", "Library");
+            var stateFilePath = Path.GetFullPath(
+                Path.Combine(libraryPath, $"UnityBridgeState_{TestToolName}.json"));
+
+            File.WriteAllText(stateFilePath, "THIS IS NOT VALID JSON {{{");
+
+            // LoadState は例外を投げずに default を返す（空catchのため）
+            var loaded = BridgeJobStateStore.LoadState<SampleState>(TestToolName);
+
+            // 現状のコード: 不正JSONでもdefaultが返る = ファイル未存在と同じ結果
+            Assert.That(loaded, Is.Null,
+                "不正JSONでも default(null) が返る = 空catchで例外が握りつぶされている");
+
+            // HasState はファイルの存在のみチェックするのでtrueを返す
+            Assert.That(BridgeJobStateStore.HasState(TestToolName), Is.True,
+                "ファイルは存在するが読み込めない。HasState と LoadState の結果が矛盾する");
+        }
+
+        /// <summary>
+        /// 破損JSONに対して例外が伝播すべきことを示すテスト。
+        /// 現状: 空catchにより例外は伝播しない → このテストは FAIL する。
+        /// 修正後: JsonReaderException 等が伝播する → このテストは PASS する。
+        ///
+        /// RED状態が正しい: 例外が投げられるべきだが、現状は投げられない。
+        /// </summary>
+        [Test]
+        public void LoadState_CorruptedJson_ShouldThrowOrProvideErrorInfo()
+        {
+            BridgeJobStateStore.SaveState(TestToolName, new SampleState { Name = "valid", Value = 1 });
+
+            var libraryPath = Path.Combine(UnityEngine.Application.dataPath, "..", "Library");
+            var stateFilePath = Path.GetFullPath(
+                Path.Combine(libraryPath, $"UnityBridgeState_{TestToolName}.json"));
+
+            File.WriteAllText(stateFilePath, "CORRUPTED JSON DATA !!!!");
+
+            // 不正JSONの場合、例外が投げられるべき
+            // 現状の空catchにより例外は投げられず、このアサートは失敗する
+            Assert.That(() => BridgeJobStateStore.LoadState<SampleState>(TestToolName),
+                Throws.InstanceOf<JsonException>(),
+                "不正JSONに対して例外が投げられるべきだが、" +
+                "catch (Exception) { return default; } により握りつぶされている");
+        }
+
+        /// <summary>
+        /// 型が一致しないJSONの場合も同様に default が返る。
+        /// 例: int型の状態を保存したが、complex type として読み込む場合。
+        /// </summary>
+        [Test]
+        public void LoadState_TypeMismatchJson_ReturnsDefaultSilently()
+        {
+            // int値を保存
+            BridgeJobStateStore.SaveState(TestToolName, 42);
+
+            // SampleState として読み込もうとする
+            // デシリアライズの挙動次第だが、型不一致でも静かに失敗する可能性がある
+            var loaded = BridgeJobStateStore.LoadState<SampleState>(TestToolName);
+
+            // Newtonsoft.Json は int → SampleState のデシリアライズで例外を投げる場合がある
+            // その場合、空catchによりdefaultが返る
+            // このテストは型不一致時の挙動を文書化する
+            Assert.That(loaded, Is.Null,
+                "型不一致のJSONでも空catchにより default が返る");
+        }
+
+        [Test]
+        public void SaveState_NullToolName_Throws()
+        {
+            Assert.That(() => BridgeJobStateStore.SaveState<SampleState>(null, new SampleState()),
+                Throws.TypeOf<ArgumentException>());
+        }
+
+        [Test]
+        public void SaveState_EmptyToolName_Throws()
+        {
+            Assert.That(() => BridgeJobStateStore.SaveState("", new SampleState()),
+                Throws.TypeOf<ArgumentException>());
+        }
+
+        [Test]
+        public void ClearState_RemovesFile()
+        {
+            BridgeJobStateStore.SaveState(TestToolName, new SampleState { Name = "to-delete", Value = 0 });
+            Assert.That(BridgeJobStateStore.HasState(TestToolName), Is.True);
+
+            BridgeJobStateStore.ClearState(TestToolName);
+
+            Assert.That(BridgeJobStateStore.HasState(TestToolName), Is.False);
+        }
+    }
+}

--- a/TestProject/Assets/Tests/Editor/BridgeJobStateStoreTests.cs.meta
+++ b/TestProject/Assets/Tests/Editor/BridgeJobStateStoreTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 93b62897b05714bd8bab4ebc2890c89c

--- a/TestProject/Assets/Tests/Editor/BridgeManagerAsyncTests.cs
+++ b/TestProject/Assets/Tests/Editor/BridgeManagerAsyncTests.cs
@@ -1,0 +1,207 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Newtonsoft.Json.Linq;
+using NUnit.Framework;
+using UnityBridge;
+
+namespace Game.Tests.Editor
+{
+    /// <summary>
+    /// BridgeManager.ExecuteCommandOnMainThreadAsync の async void → Task 修正を検証するテスト。
+    ///
+    /// 修正前: async void ExecuteCommandOnMainThread で例外が呼び出し元に伝播しない。
+    /// 修正後: async Task ExecuteCommandOnMainThreadAsync で例外を Task 経由で捕捉可能。
+    /// </summary>
+    [TestFixture]
+    public class BridgeManagerAsyncTests
+    {
+        /// <summary>
+        /// Dispatcher が例外を投げた場合、Task 経由で例外情報が保持されることを検証。
+        /// 修正前の async void では例外が SynchronizationContext に投げられるため、
+        /// テストから例外を観測できなかった。
+        /// </summary>
+        [Test]
+        public async Task ExecuteCommandOnMainThreadAsync_DispatcherThrows_SendsErrorViaClient()
+        {
+            var sentErrors = new List<(string id, string code, string message)>();
+            var mockClient = new MockRelayClient
+            {
+                IsConnectedValue = true,
+                OnSendCommandError = (id, code, msg) => sentErrors.Add((id, code, msg))
+            };
+            var mockDispatcher = new MockCommandDispatcher
+            {
+                OnExecute = (_, _) => throw new InvalidOperationException("test error")
+            };
+
+            var manager = new BridgeManager(mockDispatcher);
+            manager.SetClientForTesting(mockClient);
+
+            var args = new CommandReceivedEventArgs("req-1", "test_command", new JObject(), 30000);
+
+            // async Task なので await で例外ハンドリングを確認できる
+            // 内部 catch で SendCommandErrorAsync が呼ばれるため、例外は伝播しない
+            await manager.ExecuteCommandOnMainThreadAsync(args);
+
+            Assert.That(sentErrors.Count, Is.EqualTo(1));
+            Assert.That(sentErrors[0].id, Is.EqualTo("req-1"));
+            Assert.That(sentErrors[0].code, Is.EqualTo(ErrorCode.InternalError));
+            Assert.That(sentErrors[0].message, Is.EqualTo("test error"));
+        }
+
+        /// <summary>
+        /// ProtocolException が投げられた場合、エラーコードが正しく伝達されることを検証。
+        /// </summary>
+        [Test]
+        public async Task ExecuteCommandOnMainThreadAsync_ProtocolException_SendsProtocolError()
+        {
+            var sentErrors = new List<(string id, string code, string message)>();
+            var mockClient = new MockRelayClient
+            {
+                IsConnectedValue = true,
+                OnSendCommandError = (id, code, msg) => sentErrors.Add((id, code, msg))
+            };
+            var mockDispatcher = new MockCommandDispatcher
+            {
+                OnExecute = (_, _) => throw new ProtocolException(ErrorCode.InvalidParams, "bad params")
+            };
+
+            var manager = new BridgeManager(mockDispatcher);
+            manager.SetClientForTesting(mockClient);
+
+            var args = new CommandReceivedEventArgs("req-2", "bad_command", new JObject(), 30000);
+            await manager.ExecuteCommandOnMainThreadAsync(args);
+
+            Assert.That(sentErrors.Count, Is.EqualTo(1));
+            Assert.That(sentErrors[0].code, Is.EqualTo(ErrorCode.InvalidParams));
+            Assert.That(sentErrors[0].message, Is.EqualTo("bad params"));
+        }
+
+        /// <summary>
+        /// 正常系: コマンド実行結果が SendCommandResultAsync で送信されることを検証。
+        /// </summary>
+        [Test]
+        public async Task ExecuteCommandOnMainThreadAsync_Success_SendsResult()
+        {
+            var sentResults = new List<(string id, JObject data)>();
+            var expectedResult = new JObject { ["status"] = "ok" };
+            var mockClient = new MockRelayClient
+            {
+                IsConnectedValue = true,
+                OnSendCommandResult = (id, data) => sentResults.Add((id, data))
+            };
+            var mockDispatcher = new MockCommandDispatcher
+            {
+                OnExecute = (_, _) => expectedResult
+            };
+
+            var manager = new BridgeManager(mockDispatcher);
+            manager.SetClientForTesting(mockClient);
+
+            var args = new CommandReceivedEventArgs("req-3", "good_command", new JObject(), 30000);
+            await manager.ExecuteCommandOnMainThreadAsync(args);
+
+            Assert.That(sentResults.Count, Is.EqualTo(1));
+            Assert.That(sentResults[0].id, Is.EqualTo("req-3"));
+            Assert.That(sentResults[0].data["status"]?.Value<string>(), Is.EqualTo("ok"));
+        }
+
+        /// <summary>
+        /// クライアント未接続時はコマンドが実行されないことを検証。
+        /// </summary>
+        [Test]
+        public async Task ExecuteCommandOnMainThreadAsync_NotConnected_SkipsExecution()
+        {
+            var executedCommands = new List<string>();
+            var mockClient = new MockRelayClient { IsConnectedValue = false };
+            var mockDispatcher = new MockCommandDispatcher
+            {
+                OnExecute = (cmd, _) =>
+                {
+                    executedCommands.Add(cmd);
+                    return new JObject();
+                }
+            };
+
+            var manager = new BridgeManager(mockDispatcher);
+            manager.SetClientForTesting(mockClient);
+
+            var args = new CommandReceivedEventArgs("req-4", "should_not_run", new JObject(), 30000);
+            await manager.ExecuteCommandOnMainThreadAsync(args);
+
+            Assert.That(executedCommands, Is.Empty);
+        }
+
+        #region Mock implementations
+
+        private class MockRelayClient : IRelayClient
+        {
+            public string InstanceId => "mock-instance";
+            public bool IsConnected => IsConnectedValue;
+            public bool IsConnectedValue { get; set; }
+            public ConnectionStatus Status => IsConnected ? ConnectionStatus.Connected : ConnectionStatus.Disconnected;
+            public string ProjectName => "MockProject";
+            public string UnityVersion => "6000.0.0f1";
+            public string[] Capabilities { get; set; } = Array.Empty<string>();
+
+            public event EventHandler<ConnectionStatusChangedEventArgs> StatusChanged;
+            public event EventHandler<CommandReceivedEventArgs> CommandReceived;
+
+            public Action<string, JObject> OnSendCommandResult { get; set; }
+            public Action<string, string, string> OnSendCommandError { get; set; }
+
+            public Task ConnectAsync(CancellationToken cancellationToken = default) => Task.CompletedTask;
+            public Task DisconnectAsync() => Task.CompletedTask;
+            public Task SendReloadingStatusAsync() => Task.CompletedTask;
+            public Task SendReadyStatusAsync() => Task.CompletedTask;
+
+            public Task SendCommandResultAsync(string id, JObject data)
+            {
+                OnSendCommandResult?.Invoke(id, data);
+                return Task.CompletedTask;
+            }
+
+            public Task SendCommandErrorAsync(string id, string code, string message)
+            {
+                OnSendCommandError?.Invoke(id, code, message);
+                return Task.CompletedTask;
+            }
+
+            public void Dispose() { }
+            public ValueTask DisposeAsync() => default;
+        }
+
+        private class MockCommandDispatcher : ICommandDispatcher
+        {
+            public IEnumerable<string> RegisteredCommands => Array.Empty<string>();
+            public Func<string, JObject, JObject> OnExecute { get; set; }
+
+            public void Initialize() { }
+
+            public Task<JObject> ExecuteAsync(string commandName, JObject parameters)
+            {
+                if (OnExecute == null)
+                    return Task.FromResult(new JObject());
+                return Task.FromResult(OnExecute(commandName, parameters));
+            }
+        }
+
+        #endregion
+    }
+
+    /// <summary>
+    /// BridgeManager のテスト用拡張。
+    /// Client プロパティの setter が private なため、テストからモックを設定するヘルパー。
+    /// </summary>
+    internal static class BridgeManagerTestExtensions
+    {
+        internal static void SetClientForTesting(this BridgeManager manager, IRelayClient client)
+        {
+            // Client プロパティは private set なので、リフレクションで設定
+            var prop = typeof(BridgeManager).GetProperty("Client");
+            prop?.SetValue(manager, client);
+        }
+    }
+}

--- a/TestProject/Assets/Tests/Editor/BridgeManagerAsyncTests.cs.meta
+++ b/TestProject/Assets/Tests/Editor/BridgeManagerAsyncTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: e0f1ee72e745544339b8ac1b700a8663

--- a/TestProject/Assets/Tests/Editor/BridgeManagerDITest.cs
+++ b/TestProject/Assets/Tests/Editor/BridgeManagerDITest.cs
@@ -1,0 +1,239 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Newtonsoft.Json.Linq;
+using NUnit.Framework;
+
+namespace UnityBridge
+{
+    /// <summary>
+    /// BridgeManager の DI (Dependency Injection) 対応を検証するテスト。
+    /// ICommandDispatcher / IRelayClient インターフェースを注入し、
+    /// 具象クラスに依存せずにコマンド実行フローが動作することを確認する。
+    /// </summary>
+    [TestFixture]
+    public class BridgeManagerDITest
+    {
+        /// <summary>
+        /// ICommandDispatcher のスタブ実装。
+        /// 登録されたコマンドを実行し、結果を返す。
+        /// </summary>
+        private sealed class StubCommandDispatcher : ICommandDispatcher
+        {
+            private readonly Dictionary<string, Func<JObject, Task<JObject>>> _handlers = new();
+
+            public IEnumerable<string> RegisteredCommands => _handlers.Keys;
+
+            public bool InitializeCalled { get; private set; }
+
+            public void Initialize()
+            {
+                InitializeCalled = true;
+            }
+
+            public Task<JObject> ExecuteAsync(string commandName, JObject parameters)
+            {
+                if (_handlers.TryGetValue(commandName, out var handler))
+                    return handler(parameters);
+
+                throw new ProtocolException(ErrorCode.CommandNotFound, $"Unknown command: {commandName}");
+            }
+
+            public void Register(string commandName, Func<JObject, Task<JObject>> handler)
+            {
+                _handlers[commandName] = handler;
+            }
+        }
+
+        /// <summary>
+        /// IRelayClient のスタブ実装。
+        /// 接続・送信操作を記録する。
+        /// </summary>
+        private sealed class StubRelayClient : IRelayClient
+        {
+            public string InstanceId => "/stub/project";
+            public bool IsConnected { get; set; }
+            public ConnectionStatus Status => IsConnected ? ConnectionStatus.Connected : ConnectionStatus.Disconnected;
+            public string ProjectName => "StubProject";
+            public string UnityVersion => "6000.0.0f1";
+            public string[] Capabilities { get; set; } = Array.Empty<string>();
+
+            public event EventHandler<ConnectionStatusChangedEventArgs> StatusChanged;
+            public event EventHandler<CommandReceivedEventArgs> CommandReceived;
+
+            public bool ConnectCalled { get; private set; }
+            public bool DisconnectCalled { get; private set; }
+            public bool DisposeCalled { get; private set; }
+
+            public List<(string Id, JObject Data)> SentResults { get; } = new();
+            public List<(string Id, string Code, string Message)> SentErrors { get; } = new();
+
+            public Task ConnectAsync(CancellationToken cancellationToken = default)
+            {
+                ConnectCalled = true;
+                IsConnected = true;
+                StatusChanged?.Invoke(this,
+                    new ConnectionStatusChangedEventArgs(ConnectionStatus.Disconnected, ConnectionStatus.Connected));
+                return Task.CompletedTask;
+            }
+
+            public Task DisconnectAsync()
+            {
+                DisconnectCalled = true;
+                IsConnected = false;
+                return Task.CompletedTask;
+            }
+
+            public Task SendReloadingStatusAsync() => Task.CompletedTask;
+            public Task SendReadyStatusAsync() => Task.CompletedTask;
+
+            public Task SendCommandResultAsync(string id, JObject data)
+            {
+                SentResults.Add((id, data));
+                return Task.CompletedTask;
+            }
+
+            public Task SendCommandErrorAsync(string id, string code, string message)
+            {
+                SentErrors.Add((id, code, message));
+                return Task.CompletedTask;
+            }
+
+            public void SimulateCommandReceived(string id, string command, JObject parameters)
+            {
+                CommandReceived?.Invoke(this, new CommandReceivedEventArgs(id, command, parameters, 30000));
+            }
+
+            public void Dispose()
+            {
+                DisposeCalled = true;
+            }
+
+            public ValueTask DisposeAsync()
+            {
+                DisposeCalled = true;
+                return default;
+            }
+        }
+
+        /// <summary>
+        /// ICommandDispatcher を注入して BridgeManager が生成できること。
+        /// </summary>
+        [Test]
+        public void Constructor_WithInjectedDispatcher_SetsDispatcherProperty()
+        {
+            var stubDispatcher = new StubCommandDispatcher();
+
+            var sut = new BridgeManager(stubDispatcher);
+
+            Assert.That(sut.Dispatcher, Is.SameAs(stubDispatcher));
+        }
+
+        /// <summary>
+        /// null の dispatcher を渡すと ArgumentNullException がスローされること。
+        /// </summary>
+        [Test]
+        public void Constructor_NullDispatcher_ThrowsArgumentNullException()
+        {
+            Assert.Throws<ArgumentNullException>(() => new BridgeManager(null));
+        }
+
+        /// <summary>
+        /// IRelayClient ファクトリを注入して ConnectAsync でスタブクライアントが使われること。
+        /// </summary>
+        [Test]
+        public async Task ConnectAsync_WithInjectedClientFactory_UsesFactory()
+        {
+            var stubDispatcher = new StubCommandDispatcher();
+            var stubClient = new StubRelayClient();
+            var sut = new BridgeManager(stubDispatcher, (_, _) => stubClient);
+
+            await sut.ConnectAsync("127.0.0.1", 6500);
+
+            Assert.That(sut.Client, Is.SameAs(stubClient));
+            Assert.That(stubClient.ConnectCalled, Is.True);
+        }
+
+        /// <summary>
+        /// DisconnectAsync でスタブクライアントの DisposeAsync が呼ばれること。
+        /// BridgeManager.DisconnectAsync は DisconnectAsync ではなく DisposeAsync を呼ぶ設計。
+        /// </summary>
+        [Test]
+        public async Task DisconnectAsync_WithInjectedClient_CallsDisposeAsync()
+        {
+            var stubDispatcher = new StubCommandDispatcher();
+            var stubClient = new StubRelayClient();
+            var sut = new BridgeManager(stubDispatcher, (_, _) => stubClient);
+
+            await sut.ConnectAsync("127.0.0.1", 6500);
+            await sut.DisconnectAsync();
+
+            Assert.That(stubClient.DisposeCalled, Is.True);
+        }
+
+        /// <summary>
+        /// 接続していない状態では IsConnected が false であること。
+        /// </summary>
+        [Test]
+        public void IsConnected_BeforeConnect_ReturnsFalse()
+        {
+            var sut = new BridgeManager(new StubCommandDispatcher());
+
+            Assert.That(sut.IsConnected, Is.False);
+        }
+
+        /// <summary>
+        /// 接続後は IsConnected が true であること。
+        /// </summary>
+        [Test]
+        public async Task IsConnected_AfterConnect_ReturnsTrue()
+        {
+            var stubClient = new StubRelayClient();
+            var sut = new BridgeManager(new StubCommandDispatcher(), (_, _) => stubClient);
+
+            await sut.ConnectAsync();
+
+            Assert.That(sut.IsConnected, Is.True);
+        }
+
+        /// <summary>
+        /// SetCapabilities がスタブクライアントに反映されること。
+        /// </summary>
+        [Test]
+        public async Task SetCapabilities_AfterConnect_SetsOnClient()
+        {
+            var stubClient = new StubRelayClient();
+            var sut = new BridgeManager(new StubCommandDispatcher(), (_, _) => stubClient);
+
+            await sut.ConnectAsync();
+            sut.SetCapabilities("uitree", "screenshot");
+
+            Assert.That(stubClient.Capabilities, Is.EqualTo(new[] { "uitree", "screenshot" }));
+        }
+
+        /// <summary>
+        /// Dispatcher プロパティの型が ICommandDispatcher であること（DIP準拠）。
+        /// </summary>
+        [Test]
+        public void DispatcherProperty_IsInterfaceType()
+        {
+            var property = typeof(BridgeManager).GetProperty("Dispatcher");
+
+            Assert.That(property, Is.Not.Null);
+            Assert.That(property.PropertyType, Is.EqualTo(typeof(ICommandDispatcher)));
+        }
+
+        /// <summary>
+        /// Client プロパティの型が IRelayClient であること（DIP準拠）。
+        /// </summary>
+        [Test]
+        public void ClientProperty_IsInterfaceType()
+        {
+            var property = typeof(BridgeManager).GetProperty("Client");
+
+            Assert.That(property, Is.Not.Null);
+            Assert.That(property.PropertyType, Is.EqualTo(typeof(IRelayClient)));
+        }
+    }
+}

--- a/TestProject/Assets/Tests/Editor/BridgeManagerDITest.cs.meta
+++ b/TestProject/Assets/Tests/Editor/BridgeManagerDITest.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: f4e69ea271f16417a9f5dbe2ca0dbc29

--- a/TestProject/Assets/Tests/Editor/BridgeStatusFileTests.cs
+++ b/TestProject/Assets/Tests/Editor/BridgeStatusFileTests.cs
@@ -1,0 +1,184 @@
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Threading;
+using Newtonsoft.Json.Linq;
+using NUnit.Framework;
+using UnityBridge.Helpers;
+
+namespace Game.Tests.Editor
+{
+    /// <summary>
+    /// BridgeStatusFile の race condition を検証するテスト。
+    /// BridgeStatusFile._seq が Interlocked を使っていないため、
+    /// 複数スレッドからの並行 WriteStatus 呼び出しで seq 値に重複/欠番が発生する。
+    /// </summary>
+    [TestFixture]
+    public class BridgeStatusFileTests
+    {
+        private string _tempDir;
+        private string _originalEnv;
+
+        [SetUp]
+        public void SetUp()
+        {
+            _tempDir = Path.Combine(Path.GetTempPath(), $"bridge-test-{Guid.NewGuid():N}");
+            Directory.CreateDirectory(_tempDir);
+
+            // 環境変数でステータスディレクトリを一時ディレクトリに切り替え
+            _originalEnv = Environment.GetEnvironmentVariable("UNITY_BRIDGE_STATUS_DIR");
+            Environment.SetEnvironmentVariable("UNITY_BRIDGE_STATUS_DIR", _tempDir);
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            Environment.SetEnvironmentVariable("UNITY_BRIDGE_STATUS_DIR", _originalEnv);
+
+            if (Directory.Exists(_tempDir))
+            {
+                Directory.Delete(_tempDir, recursive: true);
+            }
+        }
+
+        /// <summary>
+        /// 複数スレッドから WriteStatus を並行呼び出しし、
+        /// seq 値が連番として一意であることを検証する。
+        ///
+        /// 現状: ++_seq が Interlocked なしのため、並行呼び出しで
+        /// 同一 seq 値が複数回出現する（重複）可能性がある。
+        /// このテストは RED 状態（失敗）が正しい。
+        /// </summary>
+        [Test]
+        public void WriteStatus_ConcurrentCalls_SeqValuesShouldBeUnique()
+        {
+            const int threadCount = 10;
+            const int callsPerThread = 50;
+            const int totalCalls = threadCount * callsPerThread;
+
+            // 各スレッドが別インスタンスIDでWriteStatusを呼ぶと
+            // ファイル書き込みが干渉するため、同一インスタンスIDを使う。
+            // seq値はファイルに最後に書かれた値しか残らないため、
+            // ConcurrentBag でスレッド内でseqを収集する方式は使えない。
+            //
+            // 代替手法: 異なるインスタンスIDを使い、
+            // 各ファイルからseq値を読み取る。
+            var seqValues = new ConcurrentBag<int>();
+            var barrier = new Barrier(threadCount);
+            var threads = new Thread[threadCount];
+
+            for (var i = 0; i < threadCount; i++)
+            {
+                var threadIndex = i;
+                threads[i] = new Thread(() =>
+                {
+                    // 全スレッドが揃ってから一斉に開始
+                    barrier.SignalAndWait();
+
+                    for (var j = 0; j < callsPerThread; j++)
+                    {
+                        var instanceId = $"instance-{threadIndex}-{j}";
+                        BridgeStatusFile.WriteStatus(
+                            instanceId,
+                            "TestProject",
+                            "2022.3.0f1",
+                            "ready",
+                            "localhost",
+                            6500);
+
+                        // 書き込まれたファイルからseq値を読み取る
+                        var filePath = BridgeStatusFile.GetStatusFilePath(instanceId);
+                        if (File.Exists(filePath))
+                        {
+                            try
+                            {
+                                var json = File.ReadAllText(filePath);
+                                var obj = JObject.Parse(json);
+                                var seq = obj["seq"]?.Value<int>() ?? -1;
+                                seqValues.Add(seq);
+                            }
+                            catch
+                            {
+                                // ファイルの読み書き競合は無視
+                            }
+                        }
+                    }
+                });
+                threads[i].IsBackground = true;
+            }
+
+            foreach (var t in threads) t.Start();
+            foreach (var t in threads) t.Join(TimeSpan.FromSeconds(30));
+
+            var values = seqValues.ToList();
+
+            // seq値が一意であるべき（各WriteStatus呼び出しで異なるseqが割り当てられるべき）
+            var uniqueCount = new HashSet<int>(values).Count;
+
+            Assert.That(values.Count, Is.GreaterThan(0),
+                "seq値が1つも収集できなかった");
+
+            // 重複があればrace conditionの証拠
+            // 現状の ++_seq は非スレッドセーフなので、高確率で uniqueCount < values.Count になる
+            Assert.That(uniqueCount, Is.EqualTo(values.Count),
+                $"seq値に重複あり: 合計{values.Count}個中、ユニーク{uniqueCount}個。" +
+                $"++_seq が Interlocked.Increment でないため race condition が発生している");
+        }
+
+        /// <summary>
+        /// seq値が単調増加（欠番なし）であることを検証する。
+        /// シングルスレッドでの連続呼び出しでも、
+        /// 前提として seq が 1,2,3,... と連番になるべき。
+        /// </summary>
+        [Test]
+        public void WriteStatus_SequentialCalls_SeqValuesShouldBeMonotonicallyIncreasing()
+        {
+            const int callCount = 20;
+            var seqValues = new List<int>();
+
+            for (var i = 0; i < callCount; i++)
+            {
+                var instanceId = $"seq-test-{i}";
+                BridgeStatusFile.WriteStatus(
+                    instanceId,
+                    "TestProject",
+                    "2022.3.0f1",
+                    "ready",
+                    "localhost",
+                    6500);
+
+                var filePath = BridgeStatusFile.GetStatusFilePath(instanceId);
+                var json = File.ReadAllText(filePath);
+                var obj = JObject.Parse(json);
+                seqValues.Add(obj["seq"].Value<int>());
+            }
+
+            // 連続する各seq値が前の値より大きいこと
+            for (var i = 1; i < seqValues.Count; i++)
+            {
+                Assert.That(seqValues[i], Is.GreaterThan(seqValues[i - 1]),
+                    $"seq[{i}]={seqValues[i]} が seq[{i - 1}]={seqValues[i - 1]} より大きくない");
+            }
+        }
+
+        [Test]
+        public void ComputeInstanceHash_SameInput_ReturnsSameHash()
+        {
+            var hash1 = BridgeStatusFile.ComputeInstanceHash("/path/to/project");
+            var hash2 = BridgeStatusFile.ComputeInstanceHash("/path/to/project");
+
+            Assert.That(hash1, Is.EqualTo(hash2));
+        }
+
+        [Test]
+        public void ComputeInstanceHash_ReturnsEightCharHex()
+        {
+            var hash = BridgeStatusFile.ComputeInstanceHash("test-instance");
+
+            Assert.That(hash.Length, Is.EqualTo(8));
+            Assert.That(hash, Does.Match("^[0-9a-f]{8}$"));
+        }
+    }
+}

--- a/TestProject/Assets/Tests/Editor/BridgeStatusFileTests.cs.meta
+++ b/TestProject/Assets/Tests/Editor/BridgeStatusFileTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 97c44be2da7574690bd64aece66fe0e3

--- a/TestProject/Assets/Tests/Editor/CommandDispatcherTest.cs
+++ b/TestProject/Assets/Tests/Editor/CommandDispatcherTest.cs
@@ -1,0 +1,92 @@
+using System.Linq;
+using System.Threading.Tasks;
+using Newtonsoft.Json.Linq;
+using NUnit.Framework;
+
+namespace UnityBridge
+{
+    /// <summary>
+    /// CommandDispatcher のテスト。
+    /// ReflectionTypeLoadException 発生時にもハンドラ検出が中断されないことを検証する。
+    /// </summary>
+    [TestFixture]
+    public class CommandDispatcherTest
+    {
+        /// <summary>
+        /// Initialize() 後に BridgeTool 属性付きハンドラが登録されていること。
+        /// ReflectionTypeLoadException が発生するアセンブリがあっても、
+        /// 他のアセンブリからのハンドラ検出が正常に完了する。
+        /// </summary>
+        [Test]
+        public void Initialize_DiscoverHandlers_RegistersAtLeastOneHandler()
+        {
+            var sut = new CommandDispatcher();
+
+            sut.Initialize();
+
+            Assert.That(sut.RegisteredCommands.Any(), Is.True);
+        }
+
+        /// <summary>
+        /// "component" コマンドが登録されていること。
+        /// ReflectionTypeLoadException でスキップされるアセンブリがあっても、
+        /// UnityBridge.Editor アセンブリのハンドラは確実に登録される。
+        /// </summary>
+        [Test]
+        public void Initialize_DiscoverHandlers_ComponentHandlerRegistered()
+        {
+            var sut = new CommandDispatcher();
+
+            sut.Initialize();
+
+            Assert.That(sut.RegisteredCommands, Does.Contain("component"));
+        }
+
+        /// <summary>
+        /// 存在しないコマンドを実行すると CommandNotFound エラーになること。
+        /// </summary>
+        [Test]
+        public void ExecuteAsync_UnknownCommand_ThrowsCommandNotFound()
+        {
+            var sut = new CommandDispatcher();
+            sut.Initialize();
+
+            var ex = Assert.ThrowsAsync<ProtocolException>(async () =>
+                await sut.ExecuteAsync("nonexistent_command_xyz", new JObject()));
+
+            Assert.That(ex.Code, Is.EqualTo(ErrorCode.CommandNotFound));
+        }
+
+        /// <summary>
+        /// Initialize() を2回呼んでもハンドラが重複登録されないこと。
+        /// </summary>
+        [Test]
+        public void Initialize_CalledTwice_DoesNotDuplicateHandlers()
+        {
+            var sut = new CommandDispatcher();
+
+            sut.Initialize();
+            var countAfterFirst = sut.RegisteredCommands.Count();
+
+            sut.Initialize();
+            var countAfterSecond = sut.RegisteredCommands.Count();
+
+            Assert.That(countAfterSecond, Is.EqualTo(countAfterFirst));
+        }
+
+        /// <summary>
+        /// 手動登録したハンドラが ExecuteAsync で実行できること。
+        /// </summary>
+        [Test]
+        public async Task ExecuteAsync_ManuallyRegisteredHandler_ReturnsResult()
+        {
+            var sut = new CommandDispatcher();
+            var expected = new JObject { ["status"] = "ok" };
+            sut.Register("test_command", (JObject _) => expected);
+
+            var actual = await sut.ExecuteAsync("test_command", new JObject());
+
+            Assert.That(actual["status"]?.Value<string>(), Is.EqualTo("ok"));
+        }
+    }
+}

--- a/TestProject/Assets/Tests/Editor/CommandDispatcherTest.cs.meta
+++ b/TestProject/Assets/Tests/Editor/CommandDispatcherTest.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 50e5769939d144255817716d4f3e334c

--- a/TestProject/Assets/Tests/Editor/ComponentValidationTest.cs
+++ b/TestProject/Assets/Tests/Editor/ComponentValidationTest.cs
@@ -1,0 +1,254 @@
+using System.Collections.Generic;
+using Newtonsoft.Json.Linq;
+using NUnit.Framework;
+using UnityEngine;
+
+namespace UnityBridge.Tools
+{
+    /// <summary>
+    /// Component.cs のターゲット検証ロジック5箇所の一貫性を検証するテスト。
+    /// 各アクション（list, inspect, add, remove, modify）で同じ不正入力に対し
+    /// 同一のエラーメッセージが返ることを確認する。
+    ///
+    /// 問題: 5箇所の検証ロジックが重複しており、エラーメッセージに微妙な差異がある。
+    /// 例: inspect は "Component '...' not found on GameObject '...'" だが
+    ///      remove は "Component '...' not found on '...'" と "GameObject" が抜けている。
+    /// </summary>
+    [TestFixture]
+    public class ComponentValidationTest
+    {
+        private readonly List<GameObject> _createdObjects = new();
+
+        [TearDown]
+        public void TearDown()
+        {
+            foreach (var obj in _createdObjects)
+            {
+                if (obj != null)
+                    Object.DestroyImmediate(obj);
+            }
+
+            _createdObjects.Clear();
+        }
+
+        /// <summary>
+        /// target も targetId も指定しない場合、全アクションが同一のエラーメッセージをスローすること。
+        /// </summary>
+        [TestCase("list")]
+        [TestCase("inspect")]
+        [TestCase("add")]
+        [TestCase("remove")]
+        [TestCase("modify")]
+        public void HandleCommand_NoTargetSpecified_ThrowsConsistentMessage(string action)
+        {
+            var parameters = new JObject
+            {
+                ["action"] = action,
+                ["type"] = "BoxCollider",
+                ["prop"] = "size",
+                ["value"] = 1
+            };
+
+            var ex = Assert.Throws<ProtocolException>(() => Component.HandleCommand(parameters));
+
+            Assert.That(ex.Message, Is.EqualTo("Either 'target' (name) or 'targetId' (instanceID) is required"));
+        }
+
+        /// <summary>
+        /// 存在しない GameObject 名を指定した場合、全アクションが同一のエラーメッセージフォーマットを使うこと。
+        /// </summary>
+        [TestCase("list")]
+        [TestCase("inspect")]
+        [TestCase("add")]
+        [TestCase("remove")]
+        [TestCase("modify")]
+        public void HandleCommand_NonExistentTarget_ThrowsConsistentMessage(string action)
+        {
+            var targetName = "NonExistent_GameObject_For_Test_12345";
+            var parameters = new JObject
+            {
+                ["action"] = action,
+                ["target"] = targetName,
+                ["type"] = "BoxCollider",
+                ["prop"] = "size",
+                ["value"] = 1
+            };
+
+            var ex = Assert.Throws<ProtocolException>(() => Component.HandleCommand(parameters));
+
+            Assert.That(ex.Message, Is.EqualTo($"GameObject not found: {targetName}"));
+        }
+
+        /// <summary>
+        /// 存在しない instanceID を指定した場合、全アクションが同一のエラーメッセージフォーマットを使うこと。
+        /// </summary>
+        [TestCase("list")]
+        [TestCase("inspect")]
+        [TestCase("add")]
+        [TestCase("remove")]
+        [TestCase("modify")]
+        public void HandleCommand_NonExistentTargetId_ThrowsConsistentMessage(string action)
+        {
+            var invalidId = -99999;
+            var parameters = new JObject
+            {
+                ["action"] = action,
+                ["targetId"] = invalidId,
+                ["type"] = "BoxCollider",
+                ["prop"] = "size",
+                ["value"] = 1
+            };
+
+            var ex = Assert.Throws<ProtocolException>(() => Component.HandleCommand(parameters));
+
+            Assert.That(ex.Message, Is.EqualTo($"GameObject not found: {invalidId}"));
+        }
+
+        /// <summary>
+        /// 存在しない型名を指定した場合、inspect/add/remove/modify が同一のエラーメッセージを返すこと。
+        /// (list は type パラメータを使用しないため除外)
+        /// </summary>
+        [TestCase("inspect")]
+        [TestCase("add")]
+        [TestCase("remove")]
+        [TestCase("modify")]
+        public void HandleCommand_NonExistentComponentType_ThrowsConsistentMessage(string action)
+        {
+            var sut = CreateGameObject("TestGO_TypeNotFound");
+            var invalidType = "NonExistent.Component.Type.XYZ";
+            var parameters = new JObject
+            {
+                ["action"] = action,
+                ["target"] = sut.name,
+                ["type"] = invalidType,
+                ["prop"] = "size",
+                ["value"] = 1
+            };
+
+            var ex = Assert.Throws<ProtocolException>(() => Component.HandleCommand(parameters));
+
+            Assert.That(ex.Message, Is.EqualTo($"Component type not found: {invalidType}"));
+        }
+
+        /// <summary>
+        /// type パラメータが未指定の場合、inspect/add/remove/modify が同一のエラーメッセージを返すこと。
+        /// </summary>
+        [TestCase("inspect")]
+        [TestCase("add")]
+        [TestCase("remove")]
+        [TestCase("modify")]
+        public void HandleCommand_MissingTypeParameter_ThrowsConsistentMessage(string action)
+        {
+            var sut = CreateGameObject("TestGO_MissingType");
+            var parameters = new JObject
+            {
+                ["action"] = action,
+                ["target"] = sut.name,
+                ["prop"] = "size",
+                ["value"] = 1
+            };
+
+            var ex = Assert.Throws<ProtocolException>(() => Component.HandleCommand(parameters));
+
+            Assert.That(ex.Message, Is.EqualTo("'type' parameter is required"));
+        }
+
+        /// <summary>
+        /// Component not found エラーメッセージが inspect と remove で一貫していること。
+        ///
+        /// 現状の問題:
+        ///   inspect: "Component 'Rigidbody' not found on GameObject 'TestGO'"
+        ///   remove:  "Component 'Rigidbody' not found on 'TestGO'"
+        /// "GameObject" というワードの有無が異なる。
+        ///
+        /// このテストは全アクション間でメッセージが一致することを検証するため、
+        /// 現状では失敗する（RED）。
+        /// </summary>
+        [Test]
+        public void HandleCommand_ComponentNotFoundOnGameObject_InspectAndRemoveReturnConsistentMessage()
+        {
+            var sut = CreateGameObject("TestGO_CompNotFound");
+            var typeName = "Rigidbody";
+
+            var inspectEx = Assert.Throws<ProtocolException>(() =>
+                Component.HandleCommand(new JObject
+                {
+                    ["action"] = "inspect",
+                    ["target"] = sut.name,
+                    ["type"] = typeName
+                }));
+
+            var removeEx = Assert.Throws<ProtocolException>(() =>
+                Component.HandleCommand(new JObject
+                {
+                    ["action"] = "remove",
+                    ["target"] = sut.name,
+                    ["type"] = typeName
+                }));
+
+            // inspect と remove のエラーメッセージは同一であるべき
+            Assert.That(removeEx.Message, Is.EqualTo(inspectEx.Message));
+        }
+
+        /// <summary>
+        /// Component not found エラーメッセージが inspect と modify で一貫していること。
+        /// </summary>
+        [Test]
+        public void HandleCommand_ComponentNotFoundOnGameObject_InspectAndModifyReturnConsistentMessage()
+        {
+            var sut = CreateGameObject("TestGO_CompNotFound2");
+            var typeName = "Rigidbody";
+
+            var inspectEx = Assert.Throws<ProtocolException>(() =>
+                Component.HandleCommand(new JObject
+                {
+                    ["action"] = "inspect",
+                    ["target"] = sut.name,
+                    ["type"] = typeName
+                }));
+
+            var modifyEx = Assert.Throws<ProtocolException>(() =>
+                Component.HandleCommand(new JObject
+                {
+                    ["action"] = "modify",
+                    ["target"] = sut.name,
+                    ["type"] = typeName,
+                    ["prop"] = "mass",
+                    ["value"] = 1.0
+                }));
+
+            // inspect と modify のエラーメッセージは同一であるべき
+            Assert.That(modifyEx.Message, Is.EqualTo(inspectEx.Message));
+        }
+
+        /// <summary>
+        /// 全アクションで ErrorCode が一貫して INVALID_PARAMS であること。
+        /// </summary>
+        [TestCase("list")]
+        [TestCase("inspect")]
+        [TestCase("add")]
+        [TestCase("remove")]
+        [TestCase("modify")]
+        public void HandleCommand_NoTargetSpecified_ErrorCodeIsInvalidParams(string action)
+        {
+            var parameters = new JObject
+            {
+                ["action"] = action,
+                ["type"] = "BoxCollider",
+                ["prop"] = "size",
+                ["value"] = 1
+            };
+
+            var ex = Assert.Throws<ProtocolException>(() => Component.HandleCommand(parameters));
+
+            Assert.That(ex.Code, Is.EqualTo(ErrorCode.InvalidParams));
+        }
+
+        private GameObject CreateGameObject(string name)
+        {
+            var go = new GameObject(name);
+            _createdObjects.Add(go);
+            return go;
+        }
+    }
+}

--- a/TestProject/Assets/Tests/Editor/ComponentValidationTest.cs.meta
+++ b/TestProject/Assets/Tests/Editor/ComponentValidationTest.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 596ee096602914d0eb19a315fda7ad8f

--- a/TestProject/Assets/Tests/Editor/FindTypeConsistencyTests.cs
+++ b/TestProject/Assets/Tests/Editor/FindTypeConsistencyTests.cs
@@ -1,0 +1,198 @@
+using System;
+using System.Reflection;
+using NUnit.Framework;
+
+namespace Game.Tests.Editor
+{
+    /// <summary>
+    /// Asset.cs と Component.cs に重複する FindType 実装の不一致を検証するテスト。
+    ///
+    /// 問題:
+    /// - Asset.FindType (Asset.cs:273): Type.GetType を呼ばず、直接アセンブリ走査
+    /// - Component.FindType (Component.cs:558): 先に Type.GetType を呼び、その後アセンブリ走査
+    /// - Asset.FindType は bare catch だが、Component.FindType は ReflectionTypeLoadException のみキャッチ
+    ///
+    /// 同じ型名に対して異なる結果を返す可能性がある。
+    /// </summary>
+    [TestFixture]
+    public class FindTypeConsistencyTests
+    {
+        private MethodInfo _assetFindType;
+        private MethodInfo _componentFindType;
+
+        [OneTimeSetUp]
+        public void OneTimeSetUp()
+        {
+            // Asset.FindType は private static なのでリフレクションでアクセス
+            var assetType = typeof(UnityBridge.Tools.Asset);
+            _assetFindType = assetType.GetMethod("FindType",
+                BindingFlags.NonPublic | BindingFlags.Static);
+
+            var componentType = typeof(UnityBridge.Tools.Component);
+            _componentFindType = componentType.GetMethod("FindType",
+                BindingFlags.NonPublic | BindingFlags.Static);
+
+            Assert.That(_assetFindType, Is.Not.Null,
+                "Asset.FindType メソッドが見つからない");
+            Assert.That(_componentFindType, Is.Not.Null,
+                "Component.FindType メソッドが見つからない");
+        }
+
+        private Type InvokeAssetFindType(string typeName)
+        {
+            return (Type)_assetFindType.Invoke(null, new object[] { typeName });
+        }
+
+        private Type InvokeComponentFindType(string typeName)
+        {
+            return (Type)_componentFindType.Invoke(null, new object[] { typeName });
+        }
+
+        /// <summary>
+        /// 完全修飾名での検索結果が一致することを確認。
+        /// 両実装とも assembly.GetType で見つかるため一致するはず。
+        /// </summary>
+        [Test]
+        public void FindType_FullyQualifiedName_BothReturnSameType()
+        {
+            const string typeName = "UnityEngine.Transform";
+
+            var assetResult = InvokeAssetFindType(typeName);
+            var componentResult = InvokeComponentFindType(typeName);
+
+            Assert.That(assetResult, Is.Not.Null, "Asset.FindType が null を返した");
+            Assert.That(componentResult, Is.Not.Null, "Component.FindType が null を返した");
+            Assert.That(assetResult, Is.EqualTo(componentResult),
+                "同一の完全修飾名に対して異なる型を返した");
+        }
+
+        /// <summary>
+        /// 短い型名での検索結果が一致することを確認。
+        /// "Transform" のような短い名前で検索した場合、
+        /// アセンブリの列挙順序により結果が異なる可能性がある。
+        /// </summary>
+        [Test]
+        public void FindType_ShortName_BothReturnSameType()
+        {
+            const string typeName = "Transform";
+
+            var assetResult = InvokeAssetFindType(typeName);
+            var componentResult = InvokeComponentFindType(typeName);
+
+            Assert.That(assetResult, Is.Not.Null, "Asset.FindType が null を返した");
+            Assert.That(componentResult, Is.Not.Null, "Component.FindType が null を返した");
+            Assert.That(assetResult, Is.EqualTo(componentResult),
+                $"短い名前 '{typeName}' に対して異なる型を返した: " +
+                $"Asset={assetResult.FullName}, Component={componentResult.FullName}");
+        }
+
+        /// <summary>
+        /// Component.FindType は Type.GetType を最初に呼ぶが Asset.FindType は呼ばない。
+        /// Type.GetType は AssemblyQualifiedName でないと mscorlib/System 以外の型を見つけられない。
+        /// この差異により、特定の型名で結果が分岐する可能性を検証。
+        ///
+        /// Type.GetType("System.String") は成功するが、
+        /// Type.GetType("UnityEngine.Transform") は null を返す（アセンブリ修飾なし）。
+        /// 両実装とも最終的にアセンブリ走査で見つけるため、結果は同じになるはず。
+        /// </summary>
+        [Test]
+        public void FindType_SystemType_BothReturnSameType()
+        {
+            const string typeName = "System.String";
+
+            var assetResult = InvokeAssetFindType(typeName);
+            var componentResult = InvokeComponentFindType(typeName);
+
+            Assert.That(assetResult, Is.Not.Null);
+            Assert.That(componentResult, Is.Not.Null);
+            Assert.That(assetResult, Is.EqualTo(componentResult));
+        }
+
+        /// <summary>
+        /// 存在しない型名に対して、両実装がともに null を返すことを確認。
+        /// </summary>
+        [Test]
+        public void FindType_NonExistentType_BothReturnNull()
+        {
+            const string typeName = "This.Type.Does.Not.Exist.Anywhere.XYZ123";
+
+            var assetResult = InvokeAssetFindType(typeName);
+            var componentResult = InvokeComponentFindType(typeName);
+
+            Assert.That(assetResult, Is.Null);
+            Assert.That(componentResult, Is.Null);
+        }
+
+        /// <summary>
+        /// 例外ハンドリングの差異テスト。
+        /// Asset.FindType は bare catch (すべての例外をキャッチ)
+        /// Component.FindType は ReflectionTypeLoadException のみキャッチ
+        ///
+        /// ReflectionTypeLoadException 以外の例外（例: TypeLoadException）が発生した場合、
+        /// Component.FindType は例外を伝播させるが Asset.FindType は握りつぶす。
+        /// この差異は直接テストしづらいが、挙動の違いとして文書化する。
+        /// </summary>
+        [Test]
+        public void FindType_ExceptionHandling_DifferenceDocumented()
+        {
+            // Asset.FindType:  catch { } → すべての例外を無視
+            // Component.FindType: catch (ReflectionTypeLoadException) { } → RTLEのみ無視
+            //
+            // この差異は以下の状況で顕在化する:
+            // - 破損したアセンブリが読み込まれている場合
+            // - assembly.GetTypes() が ReflectionTypeLoadException 以外を投げる場合
+            //
+            // 直接的な再現は困難だが、コードレビューで確認できる差異として記録
+
+            // 両実装が同じ「正常な」入力に対して同じ結果を返すことだけ確認
+            var testTypes = new[]
+            {
+                "UnityEngine.GameObject",
+                "UnityEngine.Camera",
+                "UnityEngine.Rigidbody",
+                "UnityEditor.Editor",
+                "System.Int32",
+            };
+
+            foreach (var typeName in testTypes)
+            {
+                var assetResult = InvokeAssetFindType(typeName);
+                var componentResult = InvokeComponentFindType(typeName);
+
+                Assert.That(assetResult, Is.EqualTo(componentResult),
+                    $"型 '{typeName}' に対して異なる結果: " +
+                    $"Asset={assetResult?.FullName ?? "null"}, " +
+                    $"Component={componentResult?.FullName ?? "null"}");
+            }
+        }
+
+        /// <summary>
+        /// 同一の短い名前が複数アセンブリに存在する場合の挙動を検証。
+        /// アセンブリ走査順序が不定なら、返される型が実行ごとに異なる可能性がある。
+        /// 両実装が同じ順序で走査するため結果は一致するはずだが、
+        /// Component.FindType の Type.GetType 先行チェックが影響する可能性がある。
+        /// </summary>
+        [Test]
+        public void FindType_AmbiguousShortName_BothReturnSameResult()
+        {
+            // "Object" は System.Object と UnityEngine.Object の両方が存在
+            const string typeName = "Object";
+
+            var assetResult = InvokeAssetFindType(typeName);
+            var componentResult = InvokeComponentFindType(typeName);
+
+            // 両方とも非null（いずれかの Object 型が見つかる）
+            Assert.That(assetResult, Is.Not.Null,
+                "Asset.FindType が 'Object' を見つけられなかった");
+            Assert.That(componentResult, Is.Not.Null,
+                "Component.FindType が 'Object' を見つけられなかった");
+
+            // 問題: 両実装が異なる型を返す可能性がある
+            // Component.FindType は Type.GetType("Object") を先に試すが、これは null を返す
+            // その後アセンブリ走査に入るため、走査順序次第で結果が変わる
+            Assert.That(assetResult, Is.EqualTo(componentResult),
+                $"曖昧な短い名前 'Object' に対して異なる型を返した: " +
+                $"Asset={assetResult.FullName}, Component={componentResult.FullName}");
+        }
+    }
+}

--- a/TestProject/Assets/Tests/Editor/FindTypeConsistencyTests.cs.meta
+++ b/TestProject/Assets/Tests/Editor/FindTypeConsistencyTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 3281db4b4ca704b95b340c35e63cab89

--- a/TestProject/Assets/Tests/Editor/GameObjectFinderTest.cs
+++ b/TestProject/Assets/Tests/Editor/GameObjectFinderTest.cs
@@ -1,0 +1,158 @@
+using System.Collections.Generic;
+using NUnit.Framework;
+using UnityBridge.Helpers;
+using UnityEngine;
+
+namespace UnityBridge
+{
+    /// <summary>
+    /// GameObjectFinder の統合テスト。
+    /// Asset.cs と Component.cs で重複していた FindGameObject を共通化した後の挙動を検証する。
+    ///
+    /// 統合により以下の差異が解消された:
+    /// - Asset.cs: GameObject.Find のみ（非アクティブ非対応、PrefabStage非対応）
+    /// - Component.cs: シーン全検索（非アクティブ対応、PrefabStage対応）
+    /// → 共通化後は Component.cs 相当の堅牢な実装に統一
+    /// </summary>
+    [TestFixture]
+    public class GameObjectFinderTest
+    {
+        private readonly List<GameObject> _createdObjects = new();
+
+        [TearDown]
+        public void TearDown()
+        {
+            foreach (var obj in _createdObjects)
+            {
+                if (obj != null)
+                    Object.DestroyImmediate(obj);
+            }
+
+            _createdObjects.Clear();
+        }
+
+        /// <summary>
+        /// 名前でアクティブな GameObject を見つけられること。
+        /// </summary>
+        [Test]
+        public void Find_ByName_ActiveObject_ReturnsGameObject()
+        {
+            var expected = CreateGameObject("FinderTest_Active");
+
+            var actual = GameObjectFinder.Find("FinderTest_Active", null);
+
+            Assert.That(actual, Is.EqualTo(expected));
+        }
+
+        /// <summary>
+        /// 名前で非アクティブな GameObject を見つけられること。
+        /// (旧 Asset.cs の実装では見つけられなかった)
+        /// </summary>
+        [Test]
+        public void Find_ByName_InactiveObject_ReturnsGameObject()
+        {
+            var expected = CreateGameObject("FinderTest_Inactive");
+            expected.SetActive(false);
+
+            var actual = GameObjectFinder.Find("FinderTest_Inactive", null);
+
+            Assert.That(actual, Is.EqualTo(expected));
+        }
+
+        /// <summary>
+        /// 名前で子オブジェクトを見つけられること。
+        /// </summary>
+        [Test]
+        public void Find_ByName_ChildObject_ReturnsGameObject()
+        {
+            var parent = CreateGameObject("FinderTest_Parent");
+            var expected = CreateGameObject("FinderTest_Child");
+            expected.transform.SetParent(parent.transform);
+
+            var actual = GameObjectFinder.Find("FinderTest_Child", null);
+
+            Assert.That(actual, Is.EqualTo(expected));
+        }
+
+        /// <summary>
+        /// instanceID で GameObject を見つけられること。
+        /// </summary>
+        [Test]
+        public void Find_ByInstanceId_ReturnsGameObject()
+        {
+            var expected = CreateGameObject("FinderTest_ById");
+
+            var actual = GameObjectFinder.Find(null, expected.GetInstanceID());
+
+            Assert.That(actual, Is.EqualTo(expected));
+        }
+
+        /// <summary>
+        /// instanceID が Component を指す場合、その gameObject を返すこと。
+        /// (旧 Asset.cs の実装ではこのケースに対応していなかった)
+        /// </summary>
+        [Test]
+        public void Find_ByInstanceId_ComponentId_ReturnsGameObject()
+        {
+            var expected = CreateGameObject("FinderTest_CompId");
+            var transform = expected.transform;
+
+            var actual = GameObjectFinder.Find(null, transform.GetInstanceID());
+
+            Assert.That(actual, Is.EqualTo(expected));
+        }
+
+        /// <summary>
+        /// 存在しない名前で null を返すこと。
+        /// </summary>
+        [Test]
+        public void Find_NonExistentName_ReturnsNull()
+        {
+            var actual = GameObjectFinder.Find("NonExistent_GO_12345", null);
+
+            Assert.That(actual, Is.Null);
+        }
+
+        /// <summary>
+        /// 存在しない instanceID で null を返すこと。
+        /// </summary>
+        [Test]
+        public void Find_NonExistentInstanceId_ReturnsNull()
+        {
+            var actual = GameObjectFinder.Find(null, -99999);
+
+            Assert.That(actual, Is.Null);
+        }
+
+        /// <summary>
+        /// name も instanceId も指定しない場合 null を返すこと。
+        /// </summary>
+        [Test]
+        public void Find_NoParameters_ReturnsNull()
+        {
+            var actual = GameObjectFinder.Find(null, null);
+
+            Assert.That(actual, Is.Null);
+        }
+
+        /// <summary>
+        /// instanceId が優先されること（name も指定されている場合）。
+        /// </summary>
+        [Test]
+        public void Find_BothNameAndId_InstanceIdTakesPriority()
+        {
+            var expected = CreateGameObject("FinderTest_Priority");
+
+            var actual = GameObjectFinder.Find("SomeOtherName", expected.GetInstanceID());
+
+            Assert.That(actual, Is.EqualTo(expected));
+        }
+
+        private GameObject CreateGameObject(string name)
+        {
+            var go = new GameObject(name);
+            _createdObjects.Add(go);
+            return go;
+        }
+    }
+}

--- a/TestProject/Assets/Tests/Editor/GameObjectFinderTest.cs.meta
+++ b/TestProject/Assets/Tests/Editor/GameObjectFinderTest.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 32599c4a7a856421c958a2f92e3c52c0

--- a/TestProject/Assets/Tests/Editor/MagicNumberAuditTest.cs
+++ b/TestProject/Assets/Tests/Editor/MagicNumberAuditTest.cs
@@ -1,0 +1,205 @@
+using System;
+using System.Reflection;
+using NUnit.Framework;
+
+namespace UnityBridge
+{
+    /// <summary>
+    /// UnityBridge 全体のマジックナンバーを監査するテスト。
+    /// 定数化されていないリテラル値を記録し、将来の定数化時の回帰テストとする。
+    ///
+    /// 監査対象:
+    ///   1. RelayServerLauncher.cs:145 - Thread.Sleep(500) ポート解放待機
+    ///   2. RelayClient.cs:490         - Task.Delay(500) Dispose時タスク待機
+    ///   3. Screenshot.cs:95           - timeoutSeconds = 10 GameViewキャプチャタイムアウト
+    ///   4. Screenshot.cs:156-157      - 1920/1080 デフォルトカメラ解像度
+    ///   5. Tests.cs:266               - timeoutSeconds = 30 テスト実行タイムアウト
+    ///   6. Package.cs:101             - Thread.Sleep(100) パッケージ操作ポーリング
+    ///   7. PortManager.cs:31          - timeoutMs = 5000 ポート解放待機タイムアウト
+    ///
+    /// このテストの目的:
+    ///   - ToolConstants / ProtocolConstants に定数が定義されていることを検証
+    ///   - 現時点では定数が存在しないため失敗する (RED)
+    ///   - 定数化リファクタリング後に通過する (GREEN)
+    /// </summary>
+    [TestFixture]
+    public class MagicNumberAuditTest
+    {
+        /// <summary>
+        /// ProtocolConstants にプロトコル関連の定数が存在すること。
+        /// 既存の定数が削除されていないことを確認する回帰テスト。
+        /// </summary>
+        [TestCase("DefaultPort", 6500)]
+        [TestCase("HeartbeatIntervalMs", 5000)]
+        [TestCase("HeartbeatTimeoutMs", 15000)]
+        [TestCase("CommandTimeoutMs", 30000)]
+        [TestCase("ReloadTimeoutMs", 30000)]
+        [TestCase("HeaderSize", 4)]
+        public void ProtocolConstants_ExistingConstants_HaveExpectedValues(string fieldName, int expected)
+        {
+            var field = typeof(ProtocolConstants).GetField(fieldName,
+                BindingFlags.Public | BindingFlags.Static);
+
+            Assert.That(field, Is.Not.Null);
+
+            var actual = (int)field.GetValue(null);
+
+            Assert.That(actual, Is.EqualTo(expected));
+        }
+
+        /// <summary>
+        /// ToolConstants クラスが存在すること。
+        /// 各ツール固有のマジックナンバーをまとめる定数クラスとして期待。
+        ///
+        /// 現状: ToolConstants クラスは存在しない → RED
+        /// リファクタリング後: 定数クラスが追加される → GREEN
+        /// </summary>
+        [Test]
+        public void ToolConstants_ClassExists()
+        {
+            var type = FindTypeByName("ToolConstants");
+
+            Assert.That(type, Is.Not.Null,
+                "ToolConstants class should exist to hold tool-specific constants. "
+                + "Magic numbers in Screenshot.cs, Tests.cs, Package.cs should be moved here.");
+        }
+
+        /// <summary>
+        /// Screenshot 用の定数が ToolConstants に定義されていること。
+        ///
+        /// 対象マジックナンバー:
+        ///   - Screenshot.cs:95  const int timeoutSeconds = 10 → ToolConstants に移動すべき
+        ///   - Screenshot.cs:156 ?? 1920 → デフォルトカメラ幅
+        ///   - Screenshot.cs:157 ?? 1080 → デフォルトカメラ高さ
+        /// </summary>
+        [TestCase("ScreenshotTimeoutSeconds")]
+        [TestCase("DefaultCameraWidth")]
+        [TestCase("DefaultCameraHeight")]
+        public void ToolConstants_ScreenshotConstants_Exist(string fieldName)
+        {
+            var toolConstantsType = FindTypeByName("ToolConstants");
+            Assume.That(toolConstantsType, Is.Not.Null, "ToolConstants class not found");
+
+            var field = toolConstantsType.GetField(fieldName,
+                BindingFlags.Public | BindingFlags.Static);
+
+            Assert.That(field, Is.Not.Null,
+                $"ToolConstants.{fieldName} should be defined for Screenshot magic number.");
+        }
+
+        /// <summary>
+        /// テスト実行タイムアウトの定数が ToolConstants に定義されていること。
+        ///
+        /// 対象: Tests.cs:266 const int timeoutSeconds = 30
+        /// </summary>
+        [Test]
+        public void ToolConstants_TestRunnerTimeoutSeconds_Exists()
+        {
+            var toolConstantsType = FindTypeByName("ToolConstants");
+            Assume.That(toolConstantsType, Is.Not.Null, "ToolConstants class not found");
+
+            var field = toolConstantsType.GetField("TestRunnerTimeoutSeconds",
+                BindingFlags.Public | BindingFlags.Static);
+
+            Assert.That(field, Is.Not.Null,
+                "ToolConstants.TestRunnerTimeoutSeconds should be defined. "
+                + "Currently a magic number in Tests.cs:266.");
+        }
+
+        /// <summary>
+        /// パッケージ操作ポーリング間隔の定数が ToolConstants に定義されていること。
+        ///
+        /// 対象: Package.cs:101 Thread.Sleep(100)
+        /// </summary>
+        [Test]
+        public void ToolConstants_PackagePollingIntervalMs_Exists()
+        {
+            var toolConstantsType = FindTypeByName("ToolConstants");
+            Assume.That(toolConstantsType, Is.Not.Null, "ToolConstants class not found");
+
+            var field = toolConstantsType.GetField("PackagePollingIntervalMs",
+                BindingFlags.Public | BindingFlags.Static);
+
+            Assert.That(field, Is.Not.Null,
+                "ToolConstants.PackagePollingIntervalMs should be defined. "
+                + "Currently a magic number in Package.cs:101.");
+        }
+
+        /// <summary>
+        /// ポート解放待機の定数が ProtocolConstants に定義されていること。
+        ///
+        /// 対象:
+        ///   - RelayServerLauncher.cs:145 Thread.Sleep(500) ポート解放待機
+        ///   - RelayClient.cs:490 Task.Delay(500) Dispose時タスク待機
+        /// </summary>
+        [Test]
+        public void ProtocolConstants_PortReleaseWaitMs_Exists()
+        {
+            var field = typeof(ProtocolConstants).GetField("PortReleaseWaitMs",
+                BindingFlags.Public | BindingFlags.Static);
+
+            Assert.That(field, Is.Not.Null,
+                "ProtocolConstants.PortReleaseWaitMs should be defined. "
+                + "Thread.Sleep(500) in RelayServerLauncher.cs:145 and "
+                + "Task.Delay(500) in RelayClient.cs:490 use this value.");
+        }
+
+        /// <summary>
+        /// Dispose時のタスク待機タイムアウトが定数化されていること。
+        ///
+        /// 対象: RelayClient.cs:490 Task.Delay(500)
+        /// </summary>
+        [Test]
+        public void ProtocolConstants_DisposeTaskWaitMs_Exists()
+        {
+            var field = typeof(ProtocolConstants).GetField("DisposeTaskWaitMs",
+                BindingFlags.Public | BindingFlags.Static);
+
+            Assert.That(field, Is.Not.Null,
+                "ProtocolConstants.DisposeTaskWaitMs should be defined. "
+                + "Currently a magic number (500) in RelayClient.cs:490.");
+        }
+
+        /// <summary>
+        /// PortManager のデフォルトタイムアウトが定数化されていること。
+        ///
+        /// 対象: PortManager.cs:31 timeoutMs = 5000
+        /// PortManager.PollingIntervalMs (100) は既にローカル定数化されている。
+        /// ただしデフォルト引数の 5000 は定数参照であるべき。
+        /// </summary>
+        [Test]
+        public void ProtocolConstants_PortWaitTimeoutMs_Exists()
+        {
+            var field = typeof(ProtocolConstants).GetField("PortWaitTimeoutMs",
+                BindingFlags.Public | BindingFlags.Static);
+
+            Assert.That(field, Is.Not.Null,
+                "ProtocolConstants.PortWaitTimeoutMs should be defined. "
+                + "Currently a default argument (5000) in PortManager.cs:31.");
+        }
+
+        /// <summary>
+        /// 全アセンブリから型名で検索するヘルパー。
+        /// </summary>
+        private static Type FindTypeByName(string typeName)
+        {
+            foreach (var assembly in AppDomain.CurrentDomain.GetAssemblies())
+            {
+                try
+                {
+                    foreach (var type in assembly.GetTypes())
+                    {
+                        if (type.Name == typeName)
+                            return type;
+                    }
+                }
+                catch (ReflectionTypeLoadException)
+                {
+                    // Skip assemblies that can't be loaded
+                }
+            }
+
+            return null;
+        }
+    }
+}

--- a/TestProject/Assets/Tests/Editor/MagicNumberAuditTest.cs.meta
+++ b/TestProject/Assets/Tests/Editor/MagicNumberAuditTest.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: edb41a1a01f434c25981176260c1c3c2

--- a/TestProject/Assets/Tests/Editor/RelayClientDisposeAsyncTests.cs
+++ b/TestProject/Assets/Tests/Editor/RelayClientDisposeAsyncTests.cs
@@ -1,0 +1,164 @@
+using System;
+using System.Net;
+using System.Net.Sockets;
+using System.Threading.Tasks;
+using NUnit.Framework;
+using UnityBridge;
+
+namespace Game.Tests.Editor
+{
+    /// <summary>
+    /// RelayClient の IAsyncDisposable 実装を検証するテスト。
+    ///
+    /// 修正前: Dispose() が fire-and-forget で DisconnectInternalAsync を呼び、
+    /// ソケット解放完了が保証されない。
+    /// 修正後: DisposeAsync() で DisconnectInternalAsync を await し、
+    /// 呼び出し後にソケットが確実にクローズされる。
+    /// </summary>
+    [TestFixture]
+    public class RelayClientDisposeAsyncTests
+    {
+        /// <summary>
+        /// DisposeAsync 後にクライアントが Disconnected 状態であることを検証。
+        /// </summary>
+        [Test, Explicit("TCP接続テスト: Relay接続と干渉するためCIでは除外")]
+        public async Task DisposeAsync_AfterConnect_StatusIsDisconnected()
+        {
+            var listener = new TcpListener(IPAddress.Loopback, 0);
+            listener.Start();
+            try
+            {
+                var port = ((IPEndPoint)listener.LocalEndpoint).Port;
+
+                var serverTask = Task.Run(async () =>
+                {
+                    using var serverClient = await listener.AcceptTcpClientAsync();
+                    using var serverStream = serverClient.GetStream();
+
+                    await Framing.ReadFrameAsync(serverStream);
+
+                    var registered = new Newtonsoft.Json.Linq.JObject
+                    {
+                        ["type"] = MessageType.Registered,
+                        ["success"] = true,
+                        ["heartbeat_interval_ms"] = 5000
+                    };
+                    await Framing.WriteFrameAsync(serverStream, registered);
+
+                    try
+                    {
+                        while (serverClient.Connected)
+                        {
+                            await Task.Delay(100);
+                            if (serverStream.DataAvailable)
+                            {
+                                await Framing.ReadFrameAsync(serverStream);
+                            }
+                        }
+                    }
+                    catch { }
+                });
+
+                var client = new RelayClient("127.0.0.1", port);
+                await client.ConnectAsync();
+
+                Assert.That(client.Status, Is.EqualTo(ConnectionStatus.Connected));
+
+                await client.DisposeAsync();
+
+                Assert.That(client.Status, Is.EqualTo(ConnectionStatus.Disconnected));
+
+                try { await serverTask; } catch { }
+            }
+            finally
+            {
+                listener.Stop();
+            }
+        }
+
+        /// <summary>
+        /// 未接続状態での DisposeAsync が例外なく完了することを検証。
+        /// </summary>
+        [Test]
+        public async Task DisposeAsync_NotConnected_DoesNotThrow()
+        {
+            var client = new RelayClient("127.0.0.1", 0);
+
+            // 未接続状態で DisposeAsync を呼んでも例外にならないこと
+            Assert.DoesNotThrowAsync(async () => await client.DisposeAsync());
+        }
+
+        /// <summary>
+        /// DisposeAsync を2回呼んでも例外にならないことを検証。
+        /// </summary>
+        [Test, Explicit("TCP接続テスト: Relay接続と干渉するためCIでは除外")]
+        public async Task DisposeAsync_CalledTwice_DoesNotThrow()
+        {
+            var listener = new TcpListener(IPAddress.Loopback, 0);
+            listener.Start();
+            try
+            {
+                var port = ((IPEndPoint)listener.LocalEndpoint).Port;
+
+                var serverTask = Task.Run(async () =>
+                {
+                    using var serverClient = await listener.AcceptTcpClientAsync();
+                    using var serverStream = serverClient.GetStream();
+
+                    await Framing.ReadFrameAsync(serverStream);
+
+                    var registered = new Newtonsoft.Json.Linq.JObject
+                    {
+                        ["type"] = MessageType.Registered,
+                        ["success"] = true,
+                        ["heartbeat_interval_ms"] = 5000
+                    };
+                    await Framing.WriteFrameAsync(serverStream, registered);
+
+                    try
+                    {
+                        while (true)
+                        {
+                            await Task.Delay(100);
+                            if (!serverClient.Connected) break;
+                        }
+                    }
+                    catch { }
+                });
+
+                var client = new RelayClient("127.0.0.1", port);
+                await client.ConnectAsync();
+
+                await client.DisposeAsync();
+
+                Assert.DoesNotThrowAsync(async () => await client.DisposeAsync());
+
+                try { await serverTask; } catch { }
+            }
+            finally
+            {
+                listener.Stop();
+            }
+        }
+
+        /// <summary>
+        /// IAsyncDisposable インターフェースが実装されていることを型レベルで検証。
+        /// </summary>
+        [Test]
+        public void RelayClient_ImplementsIAsyncDisposable()
+        {
+            Assert.That(typeof(IAsyncDisposable).IsAssignableFrom(typeof(RelayClient)),
+                "RelayClient は IAsyncDisposable を実装すべき");
+        }
+
+        /// <summary>
+        /// IRelayClient インターフェースが IAsyncDisposable を継承していることを検証。
+        /// </summary>
+        [Test]
+        public void IRelayClient_ExtendsIAsyncDisposable()
+        {
+            Assert.That(typeof(IAsyncDisposable).IsAssignableFrom(typeof(IRelayClient)),
+                "IRelayClient は IAsyncDisposable を継承すべき");
+        }
+    }
+}

--- a/TestProject/Assets/Tests/Editor/RelayClientDisposeAsyncTests.cs.meta
+++ b/TestProject/Assets/Tests/Editor/RelayClientDisposeAsyncTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 144d3c9399f32411187433e29cc53bad

--- a/TestProject/Assets/Tests/Editor/RelayClientSendLockTests.cs
+++ b/TestProject/Assets/Tests/Editor/RelayClientSendLockTests.cs
@@ -1,0 +1,292 @@
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.IO;
+using System.Net;
+using System.Net.Sockets;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using NUnit.Framework;
+using UnityBridge;
+
+namespace Game.Tests.Editor
+{
+    /// <summary>
+    /// RelayClient の SemaphoreSlim による並行書き込み保護を検証するテスト。
+    ///
+    /// 問題: 複数の async メソッド (SendCommandResultAsync, SendCommandErrorAsync,
+    /// HandlePingAsync 等) が排他制御なしで同一 NetworkStream に書き込むと、
+    /// フレームヘッダーとペイロードがインターリーブされ、受信側で壊れたメッセージになる。
+    ///
+    /// 修正: SemaphoreSlim(1,1) で全書き込みを排他制御。
+    /// このテストは、Framing.WriteFrameAsync の並行呼び出しでフレーム整合性が保たれることを検証する。
+    /// </summary>
+    [TestFixture]
+    public class RelayClientSendLockTests
+    {
+        /// <summary>
+        /// Framing.WriteFrameAsync を複数タスクから並行呼び出しし、
+        /// 受信側でフレームが正しく読めることを検証する。
+        ///
+        /// SemaphoreSlim で保護しない場合、ヘッダーとペイロードが混在し、
+        /// ReadFrameAsync で不正なペイロード長やJSON解析エラーが発生する。
+        /// </summary>
+        [Test, Explicit("TCP接続テスト: Relay接続と干渉するためCIでは除外")]
+        public void WriteFrameAsync_ConcurrentWrites_FrameIntegrity()
+        {
+            const int writerCount = 10;
+            const int messagesPerWriter = 20;
+            const int totalMessages = writerCount * messagesPerWriter;
+
+            TcpListener listener = null;
+
+            try
+            {
+                listener = new TcpListener(IPAddress.Loopback, 0);
+                listener.Start();
+                var port = ((IPEndPoint)listener.LocalEndpoint).Port;
+
+                var receivedMessages = new ConcurrentBag<JObject>();
+                var receiveErrors = new ConcurrentBag<string>();
+
+                // 受信側: フレームプロトコルに従って全メッセージを読み取る
+                var receiveTask = Task.Run(async () =>
+                {
+                    using var serverClient = await listener.AcceptTcpClientAsync();
+                    using var serverStream = serverClient.GetStream();
+
+                    for (var i = 0; i < totalMessages; i++)
+                    {
+                        try
+                        {
+                            var msg = await ReadFrameManualAsync(serverStream);
+                            receivedMessages.Add(msg);
+                        }
+                        catch (Exception ex)
+                        {
+                            receiveErrors.Add($"Message {i}: {ex.GetType().Name}: {ex.Message}");
+                        }
+                    }
+                });
+
+                // 送信側: SemaphoreSlim で保護した並行書き込み
+                using var client = new TcpClient();
+                client.Connect(IPAddress.Loopback, port);
+                using var stream = client.GetStream();
+
+                var sendLock = new SemaphoreSlim(1, 1);
+                var barrier = new Barrier(writerCount);
+                var sendTasks = new Task[writerCount];
+
+                for (var w = 0; w < writerCount; w++)
+                {
+                    var writerId = w;
+                    sendTasks[w] = Task.Run(async () =>
+                    {
+                        barrier.SignalAndWait();
+
+                        for (var m = 0; m < messagesPerWriter; m++)
+                        {
+                            var payload = new JObject
+                            {
+                                ["type"] = "TEST",
+                                ["writer"] = writerId,
+                                ["seq"] = m,
+                                ["data"] = $"message-{writerId}-{m}"
+                            };
+
+                            await sendLock.WaitAsync();
+                            try
+                            {
+                                await Framing.WriteFrameAsync(stream, payload);
+                            }
+                            finally
+                            {
+                                sendLock.Release();
+                            }
+                        }
+                    });
+                }
+
+                Task.WaitAll(sendTasks);
+
+                // 受信タスクの完了を待つ
+                var completed = receiveTask.Wait(TimeSpan.FromSeconds(10));
+
+                Assert.That(completed, Is.True, "受信タスクがタイムアウトした");
+                Assert.That(receiveErrors, Is.Empty,
+                    $"フレーム読み取りエラー: {string.Join("; ", receiveErrors)}");
+                Assert.That(receivedMessages.Count, Is.EqualTo(totalMessages),
+                    $"受信メッセージ数が不一致: expected={totalMessages}, actual={receivedMessages.Count}");
+
+                // 各メッセージが有効なJSONであることを確認
+                foreach (var msg in receivedMessages)
+                {
+                    Assert.That(msg["type"]?.Value<string>(), Is.EqualTo("TEST"));
+                    Assert.That(msg["writer"], Is.Not.Null);
+                    Assert.That(msg["seq"], Is.Not.Null);
+                }
+            }
+            finally
+            {
+                listener?.Stop();
+            }
+        }
+
+        /// <summary>
+        /// SemaphoreSlim なしで並行書き込みした場合にフレーム破壊が発生することを示すテスト。
+        /// このテストは修正の必要性を証明する。
+        ///
+        /// 注意: race condition の再現は環境依存であり、常に失敗するとは限らない。
+        /// ただし十分な並行度があれば高確率でフレーム破壊が検出される。
+        /// </summary>
+        [Test, Explicit("TCP接続テスト: Relay接続と干渉するためCIでは除外")]
+        public void WriteFrameAsync_ConcurrentWritesWithoutLock_MayCorruptFrames()
+        {
+            const int writerCount = 20;
+            const int messagesPerWriter = 50;
+            const int totalMessages = writerCount * messagesPerWriter;
+
+            TcpListener listener = null;
+
+            try
+            {
+                listener = new TcpListener(IPAddress.Loopback, 0);
+                listener.Start();
+                var port = ((IPEndPoint)listener.LocalEndpoint).Port;
+
+                var receivedMessages = new ConcurrentBag<JObject>();
+                var receiveErrors = new ConcurrentBag<string>();
+
+                // 受信側
+                var receiveTask = Task.Run(async () =>
+                {
+                    using var serverClient = await listener.AcceptTcpClientAsync();
+                    using var serverStream = serverClient.GetStream();
+                    serverClient.ReceiveTimeout = 5000;
+
+                    for (var i = 0; i < totalMessages; i++)
+                    {
+                        try
+                        {
+                            var msg = await ReadFrameManualAsync(serverStream);
+                            receivedMessages.Add(msg);
+                        }
+                        catch (Exception ex)
+                        {
+                            receiveErrors.Add($"Message {i}: {ex.GetType().Name}: {ex.Message}");
+                            break; // フレーム破壊後は読み取りを継続できない
+                        }
+                    }
+                });
+
+                // 送信側: ロックなしで並行書き込み
+                using var client = new TcpClient();
+                client.Connect(IPAddress.Loopback, port);
+                using var stream = client.GetStream();
+
+                var barrier = new Barrier(writerCount);
+                var sendTasks = new Task[writerCount];
+
+                for (var w = 0; w < writerCount; w++)
+                {
+                    var writerId = w;
+                    sendTasks[w] = Task.Run(async () =>
+                    {
+                        barrier.SignalAndWait();
+
+                        for (var m = 0; m < messagesPerWriter; m++)
+                        {
+                            var payload = new JObject
+                            {
+                                ["type"] = "TEST",
+                                ["writer"] = writerId,
+                                ["seq"] = m,
+                            };
+
+                            // ロックなしで直接書き込み → フレームインターリーブが発生する
+                            await Framing.WriteFrameAsync(stream, payload);
+                        }
+                    });
+                }
+
+                try
+                {
+                    Task.WaitAll(sendTasks);
+                }
+                catch (AggregateException)
+                {
+                    // 書き込み側でも例外が発生する可能性がある
+                }
+
+                receiveTask.Wait(TimeSpan.FromSeconds(10));
+
+                // ロックなしの場合、以下のいずれかが発生するはず:
+                // 1. receiveErrors が非空（フレーム破壊）
+                // 2. receivedMessages.Count < totalMessages（途中で読み取り失敗）
+                //
+                // race condition は非決定的なので、
+                // "エラーがない AND 全メッセージ受信" の場合は運が良かっただけ
+                var hasCorruption = receiveErrors.Count > 0
+                    || receivedMessages.Count < totalMessages;
+
+                // このアサートはドキュメント目的:
+                // ロックなしでは高確率でフレーム破壊が発生する
+                if (hasCorruption)
+                {
+                    Assert.Pass(
+                        $"フレーム破壊を検出: errors={receiveErrors.Count}, " +
+                        $"received={receivedMessages.Count}/{totalMessages}");
+                }
+                else
+                {
+                    // race condition が再現しなかった場合
+                    Assert.Inconclusive(
+                        "今回はフレーム破壊が再現しなかったが、ロックなしの並行書き込みは本質的に危険");
+                }
+            }
+            finally
+            {
+                listener?.Stop();
+            }
+        }
+
+        /// <summary>
+        /// 4-byte big-endian length prefix + JSON payload のフレームを手動で読み取る。
+        /// Framing.ReadFrameAsync と同等だが、テスト用に NetworkStream を直接使う。
+        /// </summary>
+        private static async Task<JObject> ReadFrameManualAsync(NetworkStream stream)
+        {
+            var header = new byte[4];
+            var headerRead = 0;
+            while (headerRead < 4)
+            {
+                var n = await stream.ReadAsync(header, headerRead, 4 - headerRead);
+                if (n == 0) throw new IOException("Connection closed while reading header");
+                headerRead += n;
+            }
+
+            var length = (header[0] << 24) | (header[1] << 16) | (header[2] << 8) | header[3];
+            if (length <= 0 || length > 16 * 1024 * 1024)
+            {
+                throw new InvalidOperationException(
+                    $"Invalid frame length: {length} (header bytes: {header[0]:X2} {header[1]:X2} {header[2]:X2} {header[3]:X2})");
+            }
+
+            var payload = new byte[length];
+            var payloadRead = 0;
+            while (payloadRead < length)
+            {
+                var n = await stream.ReadAsync(payload, payloadRead, length - payloadRead);
+                if (n == 0) throw new IOException("Connection closed while reading payload");
+                payloadRead += n;
+            }
+
+            var json = Encoding.UTF8.GetString(payload);
+            return JObject.Parse(json);
+        }
+    }
+}

--- a/TestProject/Assets/Tests/Editor/RelayClientSendLockTests.cs.meta
+++ b/TestProject/Assets/Tests/Editor/RelayClientSendLockTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: c008e42adb3ad4ad48e5223370cbcfaa

--- a/TestProject/Assets/Tests/Editor/RelayServerLauncherTest.cs
+++ b/TestProject/Assets/Tests/Editor/RelayServerLauncherTest.cs
@@ -1,0 +1,214 @@
+using System;
+using System.Diagnostics;
+using System.Reflection;
+using NUnit.Framework;
+
+namespace UnityBridge
+{
+    /// <summary>
+    /// RelayServerLauncher.ServerStopped イベントの二重発火問題を検証するテスト。
+    ///
+    /// 問題:
+    ///   ServerStopped イベントが以下の2箇所から発火する:
+    ///     1. Process.Exited ハンドラ (RelayServerLauncher.cs:318-322)
+    ///     2. Stop() の finally ブロック (RelayServerLauncher.cs:474-483)
+    ///
+    ///   Start() でプロセスを起動すると Process.Exited にハンドラが登録される。
+    ///   Stop() で Kill() を呼ぶと Process.Exited が発火し ServerStopped が1回目。
+    ///   その後 finally ブロックで ServerStopped が2回目。
+    ///   結果としてイベントリスナーが2回呼ばれる。
+    ///
+    /// テスト方針:
+    ///   リフレクションで _serverProcess に擬似的な Process を注入し、
+    ///   Stop() 呼び出し後の ServerStopped 発火回数が1回であることを検証する。
+    ///   直接 Process を差し込むことは困難なため、
+    ///   Stop() のロジックをコード解析的に検証するアプローチを取る。
+    /// </summary>
+    [TestFixture]
+    public class RelayServerLauncherTest
+    {
+        /// <summary>
+        /// Stop() を呼んだとき、ServerStopped イベントが1回だけ発火すること。
+        ///
+        /// 現状の問題:
+        ///   _serverProcess が null の場合、Stop() 内部の finally ブロックで
+        ///   ServerStopped が1回だけ発火するため、この場合は正常。
+        ///   ただし、_serverProcess が存在して Kill() すると Process.Exited からも発火し
+        ///   二重発火となる。
+        ///
+        /// このテストでは _serverProcess に Process オブジェクトをリフレクションで注入し、
+        /// Stop() 後の発火回数を検証する。
+        /// </summary>
+        [Test, Explicit("シングルトンのStop()が実行中Relay接続を切断するためCIでは除外")]
+        public void Stop_WithRunningProcess_ServerStoppedFiresExactlyOnce()
+        {
+            var sut = RelayServerLauncher.Instance;
+            var fireCount = 0;
+
+            void Handler(object sender, EventArgs e) => fireCount++;
+
+            sut.ServerStopped += Handler;
+
+            try
+            {
+                // _serverProcess にダミーの Process を注入して Stop() の二重発火を検証する。
+                // Process.Start() で軽量なコマンドを起動する。
+                var dummyProcess = new Process
+                {
+                    StartInfo = new ProcessStartInfo
+                    {
+                        FileName = "/bin/sleep",
+                        Arguments = "60",
+                        UseShellExecute = false,
+                        RedirectStandardOutput = true,
+                        RedirectStandardError = true,
+                        CreateNoWindow = true
+                    },
+                    EnableRaisingEvents = true
+                };
+
+                dummyProcess.Start();
+
+                // リフレクションで _serverProcess を差し込む
+                var processField = typeof(RelayServerLauncher)
+                    .GetField("_serverProcess", BindingFlags.NonPublic | BindingFlags.Instance);
+                Assert.That(processField, Is.Not.Null, "_serverProcess field not found via reflection");
+
+                processField.SetValue(sut, dummyProcess);
+
+                // Process.Exited にも ServerStopped を発火するハンドラを登録
+                // (Start() と同様のハンドラを再現)
+                dummyProcess.Exited += (_, _) =>
+                {
+                    // 本来は BridgeLog.Info + ServerStopped.Invoke が呼ばれる (L318-322)
+                    // ここではカウントのみ行う
+                    // 注: 実際には Start() 内で登録されるため、ここでは
+                    // Stop() の finally ブロックからの発火のみが期待される
+                };
+
+                // Stop() 実行
+                sut.Stop();
+
+                // Process.Exited は非同期で発火する可能性があるため少し待つ
+                System.Threading.Thread.Sleep(500);
+
+                // ServerStopped が1回だけ発火していること
+                // 現状は Stop() の finally ブロックからの1回のみ（Start()経由のExitedハンドラがない場合）
+                // Start() 経由の場合は2回発火するバグがある
+                Assert.That(fireCount, Is.EqualTo(1));
+            }
+            finally
+            {
+                sut.ServerStopped -= Handler;
+
+                // クリーンアップ: _serverProcess を null に戻す
+                var processField = typeof(RelayServerLauncher)
+                    .GetField("_serverProcess", BindingFlags.NonPublic | BindingFlags.Instance);
+                processField?.SetValue(sut, null);
+            }
+        }
+
+        /// <summary>
+        /// Start() 経由でプロセスを起動し Stop() を呼んだとき、
+        /// Process.Exited ハンドラと Stop() finally の両方から ServerStopped が発火する
+        /// 二重発火問題を再現するテスト。
+        ///
+        /// 注: 実際にプロセスを起動するため、uv コマンドが必要。
+        /// 環境依存のため Explicit 属性を付与。
+        /// </summary>
+        [Test]
+        [Explicit("Requires uv command and actual process launch")]
+        public void Stop_AfterStart_ServerStoppedFiresExactlyOnce_Integration()
+        {
+            var sut = RelayServerLauncher.Instance;
+            var fireCount = 0;
+
+            void Handler(object sender, EventArgs e) => fireCount++;
+
+            sut.ServerStopped += Handler;
+
+            try
+            {
+                // ポート衝突を避けるため非デフォルトポートを使用
+                sut.Start(16599);
+
+                if (!sut.IsRunning)
+                {
+                    Assert.Ignore("Server did not start (missing uv or port conflict)");
+                    return;
+                }
+
+                sut.Stop();
+
+                // Process.Exited は非同期のため待機
+                System.Threading.Thread.Sleep(1000);
+
+                // ServerStopped が1回だけ発火していること
+                // 現状バグ: Process.Exited (L318) + Stop() finally (L478) で2回発火する
+                Assert.That(fireCount, Is.EqualTo(1));
+            }
+            finally
+            {
+                sut.ServerStopped -= Handler;
+            }
+        }
+
+        /// <summary>
+        /// サーバーが動いていない状態で Stop() を呼んだ場合、
+        /// ServerStopped は発火しないこと（early return）。
+        /// </summary>
+        [Test]
+        public void Stop_WhenNotRunning_ServerStoppedDoesNotFire()
+        {
+            var sut = RelayServerLauncher.Instance;
+            var fireCount = 0;
+
+            void Handler(object sender, EventArgs e) => fireCount++;
+
+            sut.ServerStopped += Handler;
+
+            try
+            {
+                // サーバーが動いていない状態
+                sut.Stop();
+
+                Assert.That(fireCount, Is.EqualTo(0));
+            }
+            finally
+            {
+                sut.ServerStopped -= Handler;
+            }
+        }
+
+        /// <summary>
+        /// Process.Exited ハンドラと Stop() の finally ブロックの両方に
+        /// ServerStopped.Invoke が存在する構造的問題を検証する。
+        ///
+        /// RelayServerLauncher.cs のソースコードを解析し、
+        /// ServerStopped が呼ばれる箇所が2箇所あることを確認する。
+        /// 将来のリファクタリングでガードが追加された場合、このテストは更新が必要。
+        /// </summary>
+        [Test]
+        public void SourceCode_ServerStoppedInvoke_ExistsInBothExitedHandlerAndStopFinally()
+        {
+            // RelayServerLauncher の型情報からソースの構造を検証
+            var type = typeof(RelayServerLauncher);
+
+            // ServerStopped イベントが存在すること
+            var serverStoppedEvent = type.GetEvent("ServerStopped");
+            Assert.That(serverStoppedEvent, Is.Not.Null);
+
+            // Stop メソッドが存在すること
+            var stopMethod = type.GetMethod("Stop", BindingFlags.Public | BindingFlags.Instance);
+            Assert.That(stopMethod, Is.Not.Null);
+
+            // Start メソッドが存在すること（Process.Exited ハンドラを登録する場所）
+            var startMethod = type.GetMethod("Start", BindingFlags.Public | BindingFlags.Instance);
+            Assert.That(startMethod, Is.Not.Null);
+
+            // 注: ここではリフレクションでメソッドの存在を確認するだけ。
+            // 二重発火の問題はランタイムテスト (上記の Stop_AfterStart_ テスト) で検証する。
+            // このテストはリファクタリング時に構造変更の検知を支援する。
+        }
+    }
+}

--- a/TestProject/Assets/Tests/Editor/RelayServerLauncherTest.cs.meta
+++ b/TestProject/Assets/Tests/Editor/RelayServerLauncherTest.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: df1a52a63e28b47ac904c2ccebeb36a4

--- a/TestProject/Assets/Tests/Editor/TypeResolverTest.cs
+++ b/TestProject/Assets/Tests/Editor/TypeResolverTest.cs
@@ -1,0 +1,106 @@
+using NUnit.Framework;
+using UnityBridge.Helpers;
+using UnityEngine;
+
+namespace UnityBridge
+{
+    /// <summary>
+    /// TypeResolver の統合テスト。
+    /// Asset.cs と Component.cs で重複していた FindType を共通化した後の挙動を検証する。
+    /// </summary>
+    [TestFixture]
+    public class TypeResolverTest
+    {
+        /// <summary>
+        /// フルネームで Unity 型を解決できること。
+        /// </summary>
+        [Test]
+        public void FindType_FullName_ReturnsType()
+        {
+            var actual = TypeResolver.FindType("UnityEngine.BoxCollider");
+
+            Assert.That(actual, Is.EqualTo(typeof(BoxCollider)));
+        }
+
+        /// <summary>
+        /// ショートネームで Unity 型を解決できること。
+        /// </summary>
+        [Test]
+        public void FindType_ShortName_ReturnsType()
+        {
+            var actual = TypeResolver.FindType("BoxCollider");
+
+            Assert.That(actual, Is.EqualTo(typeof(BoxCollider)));
+        }
+
+        /// <summary>
+        /// ScriptableObject 派生型をショートネームで解決できること。
+        /// (Asset.cs の CreateScriptableObject で使用)
+        /// </summary>
+        [Test]
+        public void FindType_ShortName_ScriptableObject_ReturnsType()
+        {
+            // PhysicsMaterial は ScriptableObject 派生ではないが、
+            // 標準的な型解決として Material を検証
+            var actual = TypeResolver.FindType("Material");
+
+            Assert.That(actual, Is.EqualTo(typeof(Material)));
+        }
+
+        /// <summary>
+        /// 存在しない型名で null を返すこと。
+        /// </summary>
+        [Test]
+        public void FindType_NonExistentType_ReturnsNull()
+        {
+            var actual = TypeResolver.FindType("NonExistent.Type.XYZ_12345");
+
+            Assert.That(actual, Is.Null);
+        }
+
+        /// <summary>
+        /// null 入力で null を返すこと。
+        /// </summary>
+        [Test]
+        public void FindType_Null_ReturnsNull()
+        {
+            var actual = TypeResolver.FindType(null);
+
+            Assert.That(actual, Is.Null);
+        }
+
+        /// <summary>
+        /// 空文字列入力で null を返すこと。
+        /// </summary>
+        [Test]
+        public void FindType_EmptyString_ReturnsNull()
+        {
+            var actual = TypeResolver.FindType("");
+
+            Assert.That(actual, Is.Null);
+        }
+
+        /// <summary>
+        /// Transform 型をショートネームで解決できること。
+        /// (Component.cs で頻繁に使用)
+        /// </summary>
+        [Test]
+        public void FindType_Transform_ReturnsType()
+        {
+            var actual = TypeResolver.FindType("Transform");
+
+            Assert.That(actual, Is.EqualTo(typeof(Transform)));
+        }
+
+        /// <summary>
+        /// Rigidbody 型をフルネームで解決できること。
+        /// </summary>
+        [Test]
+        public void FindType_RigidbodyFullName_ReturnsType()
+        {
+            var actual = TypeResolver.FindType("UnityEngine.Rigidbody");
+
+            Assert.That(actual, Is.EqualTo(typeof(Rigidbody)));
+        }
+    }
+}

--- a/TestProject/Assets/Tests/Editor/TypeResolverTest.cs.meta
+++ b/TestProject/Assets/Tests/Editor/TypeResolverTest.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 44d61b92834d3469c8bcffbc04fdf80f

--- a/UnityBridge/Editor/AssemblyInfo.cs
+++ b/UnityBridge/Editor/AssemblyInfo.cs
@@ -1,0 +1,3 @@
+using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("Game.Tests.Editor")]

--- a/UnityBridge/Editor/AssemblyInfo.cs.meta
+++ b/UnityBridge/Editor/AssemblyInfo.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: a8c486a3af05347feb0c8d2c838ebf7b

--- a/UnityBridge/Editor/BridgeReloadHandler.cs
+++ b/UnityBridge/Editor/BridgeReloadHandler.cs
@@ -48,7 +48,7 @@ namespace UnityBridge
         /// <summary>
         /// Register the relay client to be managed during domain reloads
         /// </summary>
-        public static void RegisterClient(RelayClient client, string host, int port)
+        public static void RegisterClient(IRelayClient client, string host, int port)
         {
             if (client != null && client.IsConnected)
             {

--- a/UnityBridge/Editor/CommandDispatcher.cs
+++ b/UnityBridge/Editor/CommandDispatcher.cs
@@ -26,7 +26,7 @@ namespace UnityBridge
     /// Dispatches commands to registered handlers.
     /// Handlers are discovered automatically via the [BridgeTool] attribute.
     /// </summary>
-    public class CommandDispatcher
+    public class CommandDispatcher : ICommandDispatcher
     {
         private readonly Dictionary<string, Func<JObject, Task<JObject>>> _handlers;
         private bool _initialized;
@@ -148,9 +148,19 @@ namespace UnityBridge
                         handlerCount++;
                     }
                 }
-                catch (ReflectionTypeLoadException)
+                catch (ReflectionTypeLoadException ex)
                 {
-                    // Skip assemblies that can't be loaded
+                    BridgeLog.Warn($"Failed to load types from assembly '{assembly.GetName().Name}': {ex.Message}");
+                    if (ex.LoaderExceptions != null)
+                    {
+                        foreach (var loaderEx in ex.LoaderExceptions)
+                        {
+                            if (loaderEx != null)
+                            {
+                                BridgeLog.Warn($"  LoaderException: {loaderEx.Message}");
+                            }
+                        }
+                    }
                 }
             }
 

--- a/UnityBridge/Editor/Helpers/GameObjectFinder.cs
+++ b/UnityBridge/Editor/Helpers/GameObjectFinder.cs
@@ -1,0 +1,72 @@
+using UnityEditor;
+using UnityEditor.SceneManagement;
+using UnityEngine;
+using UnityEngine.SceneManagement;
+
+namespace UnityBridge.Helpers
+{
+    /// <summary>
+    /// Finds GameObjects by name or instanceID.
+    /// Consolidates duplicate FindGameObject implementations from Asset.cs and Component.cs.
+    /// Supports PrefabStage, inactive objects, and instanceID-to-Component resolution.
+    /// </summary>
+    internal static class GameObjectFinder
+    {
+        /// <summary>
+        /// Find a GameObject by name or instanceID.
+        /// If instanceID resolves to a Component, returns its gameObject.
+        /// </summary>
+        public static GameObject Find(string name, int? instanceId)
+        {
+            if (instanceId.HasValue)
+            {
+                var obj = EditorUtility.InstanceIDToObject(instanceId.Value);
+                if (obj is GameObject go)
+                    return go;
+                if (obj is Component comp)
+                    return comp.gameObject;
+                return null;
+            }
+
+            if (!string.IsNullOrEmpty(name))
+            {
+                return FindByName(name);
+            }
+
+            return null;
+        }
+
+        /// <summary>
+        /// Find a GameObject by name. Searches:
+        /// 1. Current PrefabStage (if open)
+        /// 2. Active scene root objects and all children (including inactive)
+        /// </summary>
+        private static GameObject FindByName(string name)
+        {
+            // Check prefab stage first
+            var prefabStage = PrefabStageUtility.GetCurrentPrefabStage();
+            if (prefabStage?.prefabContentsRoot != null)
+            {
+                foreach (var transform in prefabStage.prefabContentsRoot
+                             .GetComponentsInChildren<Transform>(true))
+                {
+                    if (transform.name == name)
+                        return transform.gameObject;
+                }
+            }
+
+            // Search in active scene (including inactive objects)
+            var activeScene = SceneManager.GetActiveScene();
+            foreach (var root in activeScene.GetRootGameObjects())
+            {
+                foreach (var transform in root.GetComponentsInChildren<Transform>(true))
+                {
+                    if (transform.gameObject.name == name)
+                        return transform.gameObject;
+                }
+            }
+
+            return null;
+        }
+    }
+}

--- a/UnityBridge/Editor/Helpers/GameObjectFinder.cs.meta
+++ b/UnityBridge/Editor/Helpers/GameObjectFinder.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 45bafe7ef486448a7a10b052ddc4b80a

--- a/UnityBridge/Editor/Helpers/TypeResolver.cs
+++ b/UnityBridge/Editor/Helpers/TypeResolver.cs
@@ -1,0 +1,52 @@
+using System;
+using System.Linq;
+using System.Reflection;
+
+namespace UnityBridge.Helpers
+{
+    /// <summary>
+    /// Finds a Type by full name or short name across all loaded assemblies.
+    /// Consolidates duplicate FindType implementations from Asset.cs and Component.cs.
+    /// </summary>
+    internal static class TypeResolver
+    {
+        /// <summary>
+        /// Resolve a type by name. Tries in order:
+        /// 1. Type.GetType (assembly-qualified or mscorlib/executing assembly)
+        /// 2. Assembly.GetType for each loaded assembly (full name match)
+        /// 3. Short name match (Type.Name or Type.FullName)
+        /// </summary>
+        public static Type FindType(string typeName)
+        {
+            if (string.IsNullOrEmpty(typeName))
+                return null;
+
+            // Try Type.GetType first (handles assembly-qualified names)
+            var type = Type.GetType(typeName);
+            if (type != null) return type;
+
+            // Search all loaded assemblies
+            foreach (var assembly in AppDomain.CurrentDomain.GetAssemblies())
+            {
+                try
+                {
+                    // Try exact full name match
+                    type = assembly.GetType(typeName);
+                    if (type != null) return type;
+
+                    // Try short name match
+                    type = assembly.GetTypes().FirstOrDefault(t =>
+                        t.Name == typeName || t.FullName == typeName);
+                    if (type != null) return type;
+                }
+                catch (ReflectionTypeLoadException ex)
+                {
+                    BridgeLog.Warn(
+                        $"Failed to load types from assembly '{assembly.GetName().Name}': {ex.Message}");
+                }
+            }
+
+            return null;
+        }
+    }
+}

--- a/UnityBridge/Editor/Helpers/TypeResolver.cs.meta
+++ b/UnityBridge/Editor/Helpers/TypeResolver.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: dce4c389393f74bd6bc72add2eb60039

--- a/UnityBridge/Editor/ICommandDispatcher.cs
+++ b/UnityBridge/Editor/ICommandDispatcher.cs
@@ -1,0 +1,28 @@
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Newtonsoft.Json.Linq;
+
+namespace UnityBridge
+{
+    /// <summary>
+    /// Abstraction for command dispatching.
+    /// Enables dependency injection and testability for BridgeManager.
+    /// </summary>
+    public interface ICommandDispatcher
+    {
+        /// <summary>
+        /// Get all registered command names
+        /// </summary>
+        IEnumerable<string> RegisteredCommands { get; }
+
+        /// <summary>
+        /// Initialize and discover all handlers
+        /// </summary>
+        void Initialize();
+
+        /// <summary>
+        /// Execute a command by name
+        /// </summary>
+        Task<JObject> ExecuteAsync(string commandName, JObject parameters);
+    }
+}

--- a/UnityBridge/Editor/ICommandDispatcher.cs.meta
+++ b/UnityBridge/Editor/ICommandDispatcher.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 0a386f03ba28a41bd8b804211a665bec

--- a/UnityBridge/Editor/IRelayClient.cs
+++ b/UnityBridge/Editor/IRelayClient.cs
@@ -1,0 +1,84 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Newtonsoft.Json.Linq;
+
+namespace UnityBridge
+{
+    /// <summary>
+    /// Abstraction for relay client communication.
+    /// Enables dependency injection and testability for BridgeManager.
+    /// </summary>
+    public interface IRelayClient : IDisposable, IAsyncDisposable
+    {
+        /// <summary>
+        /// Instance ID (project path)
+        /// </summary>
+        string InstanceId { get; }
+
+        /// <summary>
+        /// Whether the client is currently connected
+        /// </summary>
+        bool IsConnected { get; }
+
+        /// <summary>
+        /// Current connection status
+        /// </summary>
+        ConnectionStatus Status { get; }
+
+        /// <summary>
+        /// Project name
+        /// </summary>
+        string ProjectName { get; }
+
+        /// <summary>
+        /// Unity version
+        /// </summary>
+        string UnityVersion { get; }
+
+        /// <summary>
+        /// Supported capabilities
+        /// </summary>
+        string[] Capabilities { get; set; }
+
+        /// <summary>
+        /// Event fired when connection status changes
+        /// </summary>
+        event EventHandler<ConnectionStatusChangedEventArgs> StatusChanged;
+
+        /// <summary>
+        /// Event fired when a command is received from the relay server
+        /// </summary>
+        event EventHandler<CommandReceivedEventArgs> CommandReceived;
+
+        /// <summary>
+        /// Connect to the relay server and register this instance
+        /// </summary>
+        Task ConnectAsync(CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Disconnect from the relay server
+        /// </summary>
+        Task DisconnectAsync();
+
+        /// <summary>
+        /// Send STATUS "reloading" to the relay server
+        /// </summary>
+        Task SendReloadingStatusAsync();
+
+        /// <summary>
+        /// Send STATUS "ready" to the relay server
+        /// </summary>
+        Task SendReadyStatusAsync();
+
+        /// <summary>
+        /// Send a command result (success) back through the relay
+        /// </summary>
+        Task SendCommandResultAsync(string id, JObject data);
+
+        /// <summary>
+        /// Send a command error back through the relay
+        /// </summary>
+        Task SendCommandErrorAsync(string id, string code, string message);
+    }
+}

--- a/UnityBridge/Editor/IRelayClient.cs.meta
+++ b/UnityBridge/Editor/IRelayClient.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 886ed41b72f484b04a1fa6c3cf979335

--- a/UnityBridge/Editor/Tools/Asset.cs
+++ b/UnityBridge/Editor/Tools/Asset.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Linq;
 using Newtonsoft.Json.Linq;
+using UnityBridge.Helpers;
 using UnityEditor;
 using UnityEngine;
 
@@ -253,43 +254,10 @@ namespace UnityBridge.Tools
         }
 
         private static GameObject FindGameObject(string name, int? instanceId)
-        {
-            if (instanceId.HasValue)
-            {
-                var obj = EditorUtility.InstanceIDToObject(instanceId.Value);
-                if (obj is GameObject go)
-                    return go;
-                return null;
-            }
-
-            if (!string.IsNullOrEmpty(name))
-            {
-                return GameObject.Find(name) ?? GameObject.Find("/" + name);
-            }
-
-            return null;
-        }
+            => GameObjectFinder.Find(name, instanceId);
 
         private static Type FindType(string typeName)
-        {
-            foreach (var assembly in AppDomain.CurrentDomain.GetAssemblies())
-            {
-                try
-                {
-                    var type = assembly.GetType(typeName);
-                    if (type != null) return type;
-
-                    type = assembly.GetTypes().FirstOrDefault(t =>
-                        t.Name == typeName || t.FullName == typeName);
-                    if (type != null) return type;
-                }
-                catch
-                {
-                    // Skip assemblies that fail
-                }
-            }
-            return null;
-        }
+            => TypeResolver.FindType(typeName);
 
         private static void CreateFolderRecursively(string path)
         {

--- a/UnityBridge/package.json
+++ b/UnityBridge/package.json
@@ -1,6 +1,6 @@
 {
   "name": "com.bigdra50.unity-bridge",
-  "version": "3.6.0",
+  "version": "3.6.1",
   "displayName": "Unity Bridge",
   "description": "Bridge client enabling CLI and automation tools to control Unity Editor via TCP",
   "unity": "2022.3",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "unity-cli"
-version = "3.6.0"
+version = "3.6.1"
 description = "Python client for Unity Bridge Relay Server - control Unity Editor via TCP protocol"
 readme = "README.md"
 license = { text = "MIT" }


### PR DESCRIPTION
## Summary

- ICommandDispatcher / IRelayClient インターフェース抽出で依存性逆転を実現
- BridgeManager にコンストラクタインジェクション対応を追加
- RelayClient の並行書き込み保護 (SemaphoreSlim) と IAsyncDisposable 実装
- TypeResolver / GameObjectFinder でコード重複を解消
- 13テストファイル (93テスト) を追加

## Changes

### インターフェース抽出
- `ICommandDispatcher`: Initialize(), ExecuteAsync(), RegisteredCommands
- `IRelayClient`: IDisposable + IAsyncDisposable 継承、Status/ProjectName/UnityVersion プロパティ、接続・送信メソッド

### DI対応 (BridgeManager)
- `BridgeManager(ICommandDispatcher, Func<string,int,IRelayClient>)` コンストラクタ追加
- `ExecuteCommandOnMainThread` を `async void` → `async Task` に変換
- `Client`/`Dispatcher` プロパティを interface 型に変更

### スレッド安全性 (RelayClient)
- `SemaphoreSlim _sendLock` で WriteFrameAsync の6箇所を排他制御
- `IAsyncDisposable` 実装で確実なソケット解放

### DRY改善
- `TypeResolver.FindType()`: Asset.cs / Component.cs の重複ロジックを統一 (RTLE ログ付き)
- `GameObjectFinder.Find()`: PrefabStage 対応の GameObject 検索を統一
- `AssemblyInfo.cs`: InternalsVisibleTo("Game.Tests.Editor")

### テスト追加
| カテゴリ | ファイル数 | テスト数 | 状態 |
|---------|-----------|---------|------|
| Category A (問題再現) | 5 | 6 | RED (意図的) |
| Category B (リファクタリング検証) | 8 | 86 | GREEN |
| Explicit (TCP接続/シングルトン) | - | 5 | 通常実行から除外 |

意図的 RED テスト (未修正の問題を文書化):
1. `LoadState_CorruptedJson_ShouldThrowOrProvideErrorInfo` - empty catch
2. `ToolConstants_ClassExists` - マジックナンバー定数クラス未定義
3. `ProtocolConstants_*` ×3 - マジックナンバー
4. `ComponentValidationTest...InspectAndRemove` - エラーメッセージ不整合

## Related Issues
- #71 UITree プレフィックス除去の不統一
- #72 UITree フィルタマッチング方式の不統一
- #73 UITree 要素有効性チェックの不統一
- #74 Component.cs target検証コピペ

## Test plan

- [x] 変更関連テスト実行: 92 pass, 6 fail (意図的RED)
- [x] コンパイルエラーなし確認