### PR TITLE
screenshot PLAIN時はパスのみ出力

### DIFF
--- a/unity_cli/cli/commands/screenshot.py
+++ b/unity_cli/cli/commands/screenshot.py
@@ -10,7 +10,7 @@ from rich.markup import escape
 from unity_cli.cli.context import CLIContext
 from unity_cli.cli.exit_codes import ExitCode
 from unity_cli.cli.helpers import _handle_error, _should_json
-from unity_cli.cli.output import print_error, print_json, print_line, print_success
+from unity_cli.cli.output import OutputMode, get_output_mode, print_error, print_json, print_line, print_success
 from unity_cli.exceptions import UnityCLIError
 
 
@@ -70,11 +70,16 @@ def register(app: typer.Typer) -> None:
                 camera=camera_name,
             )
 
+            captured_path = result.get("path", "")
+
             if _should_json(context, json_flag):
                 print_json(result)
                 return
 
-            captured_path = result.get("path", "")
+            if get_output_mode() is not OutputMode.PRETTY:
+                print(captured_path)
+                return
+
             print_success(f"Screenshot captured: {captured_path}")
             if result.get("note"):
                 print_line(f"[dim]{escape(str(result.get('note')))}[/dim]")


### PR DESCRIPTION
## Summary

- screenshot コマンドの PLAIN（パイプ）出力をパスのみに変更
- JSON / PLAIN / PRETTY の3分岐に整理

```
u screenshot -s game              # PRETTY: [OK] Screenshot captured: /path
u screenshot -s game | mcat -i    # PLAIN:  /path
u screenshot -s game --json       # JSON:   {"path": "...", ...}
```

## Test plan

- [x] `pytest tests/ --ignore=tests/integration` 398 passed
- [x] ruff / mypy pass
- [ ] `u screenshot -s game | mcat -i` でパスのみ出力されインライン表示
- [ ] `u screenshot -s game --json` で JSON 出力

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **改善**
  * スクリーンショットコマンドの出力処理を改善しました。キャプチャされたスクリーンショットのパスが、出力モードに応じてより効率的に表示されるようになります。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->