### PR TITLE
Unity 2022.3 で AssetDatabase.AssetPathExists が存在しないエラーを修正

### DIFF
--- a/TestProject/Assets/Tests/Editor/AssetTest.cs
+++ b/TestProject/Assets/Tests/Editor/AssetTest.cs
@@ -1,0 +1,133 @@
+using System.Reflection;
+using Newtonsoft.Json.Linq;
+using NUnit.Framework;
+using UnityEditor;
+using UnityEngine;
+
+namespace UnityBridge.Tools
+{
+    [TestFixture]
+    public class AssetTest
+    {
+        private const string TempAssetPath = "Assets/Tests/Editor/TestData/AssetTest_Temp.anim";
+
+        [OneTimeSetUp]
+        public void OneTimeSetUp()
+        {
+            var directory = System.IO.Path.GetDirectoryName(TempAssetPath);
+            if (!AssetDatabase.IsValidFolder(directory))
+            {
+                var parts = directory.Split('/');
+                var current = parts[0];
+                for (var i = 1; i < parts.Length; i++)
+                {
+                    var next = current + "/" + parts[i];
+                    if (!AssetDatabase.IsValidFolder(next))
+                        AssetDatabase.CreateFolder(current, parts[i]);
+                    current = next;
+                }
+            }
+
+            if (AssetDatabase.LoadMainAssetAtPath(TempAssetPath) != null)
+                AssetDatabase.DeleteAsset(TempAssetPath);
+
+            var asset = new AnimationClip();
+            AssetDatabase.CreateAsset(asset, TempAssetPath);
+            AssetDatabase.SaveAssets();
+        }
+
+        [OneTimeTearDown]
+        public void OneTimeTearDown()
+        {
+            AssetDatabase.DeleteAsset(TempAssetPath);
+        }
+
+        /// <summary>
+        /// deps アクションが有効なアセットパスで正常に動作すること。
+        /// AssetPathExists が存在しない Unity 2022.3 でもコンパイル・実行できることを保証する。
+        /// </summary>
+        [Test]
+        public void HandleCommand_Deps_ValidAsset_ReturnsDependencies()
+        {
+            var actual = Asset.HandleCommand(new JObject
+            {
+                ["action"] = "deps",
+                ["path"] = TempAssetPath
+            });
+
+            Assert.That(actual["path"]?.Value<string>(), Is.EqualTo(TempAssetPath));
+        }
+
+        /// <summary>
+        /// deps アクションが存在しないパスで InvalidParams をスローすること。
+        /// バージョンに依存しない存在チェックの動作を検証する。
+        /// </summary>
+        [Test]
+        public void HandleCommand_Deps_NonExistentAsset_ThrowsInvalidParams()
+        {
+            var ex = Assert.Throws<ProtocolException>(() =>
+                Asset.HandleCommand(new JObject
+                {
+                    ["action"] = "deps",
+                    ["path"] = "Assets/NonExistent/Fake.asset"
+                }));
+
+            Assert.That(ex.Code, Is.EqualTo(ErrorCode.InvalidParams));
+        }
+
+        /// <summary>
+        /// refs アクションが有効なアセットパスで正常に動作すること。
+        /// AssetPathExists が存在しない Unity 2022.3 でもコンパイル・実行できることを保証する。
+        /// </summary>
+        [Test]
+        public void HandleCommand_Refs_ValidAsset_ReturnsReferencers()
+        {
+            var actual = Asset.HandleCommand(new JObject
+            {
+                ["action"] = "refs",
+                ["path"] = TempAssetPath
+            });
+
+            Assert.That(actual["path"]?.Value<string>(), Is.EqualTo(TempAssetPath));
+        }
+
+        /// <summary>
+        /// refs アクションが存在しないパスで InvalidParams をスローすること。
+        /// バージョンに依存しない存在チェックの動作を検証する。
+        /// </summary>
+        [Test]
+        public void HandleCommand_Refs_NonExistentAsset_ThrowsInvalidParams()
+        {
+            var ex = Assert.Throws<ProtocolException>(() =>
+                Asset.HandleCommand(new JObject
+                {
+                    ["action"] = "refs",
+                    ["path"] = "Assets/NonExistent/Fake.asset"
+                }));
+
+            Assert.That(ex.Code, Is.EqualTo(ErrorCode.InvalidParams));
+        }
+
+        /// <summary>
+        /// AssetDatabase.AssetPathExists の有無が Unity バージョンと一致すること。
+        /// Unity 6 以降では存在し、2022.3 では存在しないことをリフレクションで検証する。
+        /// #if ディレクティブの分岐が正しいことの裏付けになる。
+        /// </summary>
+        [Test]
+        public void AssetPathExists_Availability_MatchesUnityVersion()
+        {
+            var method = typeof(AssetDatabase).GetMethod(
+                "AssetPathExists",
+                BindingFlags.Public | BindingFlags.Static,
+                null,
+                new[] { typeof(string) },
+                null);
+
+#if UNITY_6000_0_OR_NEWER
+            Assert.That(method, Is.Not.Null);
+#else
+            Assert.That(method, Is.Null);
+#endif
+        }
+    }
+}

--- a/TestProject/Assets/Tests/Editor/AssetTest.cs.meta
+++ b/TestProject/Assets/Tests/Editor/AssetTest.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 93192a68c6f9b493689ad058ceb127b7
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/TestProject/Assets/Tests/Editor/TestData.meta
+++ b/TestProject/Assets/Tests/Editor/TestData.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 5528fd460bc0a4e29960043df9c679f2
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/UnityBridge/Editor/Tools/Asset.cs
+++ b/UnityBridge/Editor/Tools/Asset.cs
@@ -187,7 +187,7 @@ namespace UnityBridge.Tools
                     "'path' is required");
             }
 
-            if (!AssetDatabase.AssetPathExists(path))
+            if (!AssetPathExists(path))
             {
                 throw new ProtocolException(
                     ErrorCode.InvalidParams,
@@ -219,7 +219,7 @@ namespace UnityBridge.Tools
                     "'path' is required");
             }
 
-            if (!AssetDatabase.AssetPathExists(path))
+            if (!AssetPathExists(path))
             {
                 throw new ProtocolException(
                     ErrorCode.InvalidParams,
@@ -258,6 +258,15 @@ namespace UnityBridge.Tools
 
         private static Type FindType(string typeName)
             => TypeResolver.FindType(typeName);
+
+        private static bool AssetPathExists(string path)
+        {
+#if UNITY_6000_0_OR_NEWER
+            return AssetDatabase.AssetPathExists(path);
+#else
+            return AssetDatabase.GetMainAssetTypeAtPath(path) != null;
+#endif
+        }
 
         private static void CreateFolderRecursively(string path)
         {


### PR DESCRIPTION
## Summary

- `AssetDatabase.AssetPathExists` は Unity 6 以降のAPIのため、Unity 2022.3 でコンパイルエラーになる問題を修正
- `#if UNITY_6000_0_OR_NEWER` で分岐し、2022.3 では `AssetDatabase.GetMainAssetTypeAtPath` で代替
- `Asset.HandleCommand` の `deps` / `refs` アクションに対するテストを追加

Closes #78

## Test plan

- [x] Unity 2022.3.62f3 batchmode で `AssetTest` 5件 Passed
- [x] Unity 6000.3.5f2 batchmode で `AssetTest` 5件 Passed
- [x] Unity 2022.3 プロジェクトに対して `u asset deps` / `u asset refs` の CLI 動作確認済み

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## リリースノート

* **Tests**
  * アセット関連のエディタテストスイートを追加しました。依存・参照の取得、存在しないパスのエラー処理、Unityバージョン差分の挙動確認をカバーしています。

* **Refactor**
  * アセット存在判定の内部ロジックを整理し、複数のUnityバージョンでの互換性を向上させました。

* **Chores**
  * パッケージのバージョンを更新しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->