### PR TITLE
Relay Server にファイルログを追加

### DIFF
--- a/tests/test_relay_logging.py
+++ b/tests/test_relay_logging.py
@@ -51,6 +51,10 @@ class TestResolveLogLevel:
         # With debug flag -> DEBUG
         assert _resolve_log_level(debug_flag=True) == logging.DEBUG
 
+    def test_debug_flag_overrides_env_var(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("UNITY_CLI_LOG", "WARNING")
+        assert _resolve_log_level(debug_flag=True) == logging.DEBUG
+
 
 class TestResolveLogDir:
     def test_default_path(self, monkeypatch: pytest.MonkeyPatch) -> None:


### PR DESCRIPTION
## Summary

- Relay Server に `RotatingFileHandler` を追加し、ログをファイルに永続化
- `UNITY_CLI_LOG` 環境変数でログレベル制御
- stderr 出力は維持（併用）

## Details

| 項目 | 値 |
|------|-----|
| ログ出力先 | `$XDG_STATE_HOME/unity-cli/logs/relay.log` |
| フォールバック | `~/.local/state/unity-cli/logs/relay.log` |
| ローテーション | 10MB x 5世代 (最大50MB) |
| レベル制御 | `--debug` フラグ / `UNITY_CLI_LOG=DEBUG` 環境変数 |

```bash
# デバッグログ有効化
UNITY_CLI_LOG=DEBUG unity-relay

# ログ確認
tail -f ~/.local/state/unity-cli/logs/relay.log
```

Closes #84

## Test plan

- [x] `pytest tests/test_relay_logging.py` 10 passed
- [x] `pytest tests/ --ignore=tests/integration` 408 passed
- [x] ruff check pass
- [ ] `unity-relay` 起動後 `~/.local/state/unity-cli/logs/relay.log` が作成される
- [ ] ログレベル制御: `UNITY_CLI_LOG=DEBUG unity-relay` で DEBUG 出力

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * ファイル出力対応のログを追加し、自動ローテーションとバックアップが行われます
  * デバッグフラグや環境変数でログレベルを制御可能になりました
  * ログ保存先の解決と取得が可能になり、権限状況に応じたフォールバック動作を備えます
* **テスト**
  * ログ設定、レベル解決、保存先、ローテーション、ハンドラの動作や権限エラー時のフォールバックを検証する単体テストを追加しました
<!-- end of auto-generated comment: release notes by coderabbit.ai -->