### PR TITLE
uitree dump パネル一覧をパイプ/grep/xargs 対応に改善

### DIFF
--- a/UnityBridge/Editor/Tools/UITree.cs
+++ b/UnityBridge/Editor/Tools/UITree.cs
@@ -24,6 +24,8 @@ namespace UnityBridge.Tools
 
         private static readonly Dictionary<string, WeakReference<VisualElement>> RefMap = new();
         private static readonly ConditionalWeakTable<VisualElement, string> ElementToRef = new();
+        private static readonly Dictionary<Type, PropertyInfo> ActualViewPropCache = new();
+        private static readonly Dictionary<Type, (PropertyInfo contextType, PropertyInfo visualTree, PropertyInfo ownerObject)> PanelPropCache = new();
         private static int _epoch;
         private static int _nextSeq = 1;
 
@@ -372,27 +374,19 @@ namespace UnityBridge.Tools
         private static JObject ListPanels()
         {
             var panels = new JArray();
+            var allPanels = ResolveAllPanels(countElements: true);
 
-            // Editor panels via reflection
-            foreach (var info in GetEditorPanels())
+            foreach (var info in allPanels)
             {
-                panels.Add(new JObject
+                var panelObj = new JObject
                 {
                     ["name"] = info.Name,
                     ["contextType"] = info.ContextType,
                     ["elementCount"] = info.ElementCount
-                });
-            }
-
-            // Runtime panels via UIDocument
-            foreach (var info in GetRuntimePanels())
-            {
-                panels.Add(new JObject
-                {
-                    ["name"] = info.Name,
-                    ["contextType"] = info.ContextType,
-                    ["elementCount"] = info.ElementCount
-                });
+                };
+                if (info.WindowType != null)
+                    panelObj["windowType"] = info.WindowType;
+                panels.Add(panelObj);
             }
 
             return new JObject
@@ -403,32 +397,17 @@ namespace UnityBridge.Tools
 
         private static (VisualElement root, string panelName) FindPanelRoot(string panelName)
         {
-            // Search editor panels
-            foreach (var info in GetEditorPanels())
-            {
-                if (info.Name.Equals(panelName, StringComparison.OrdinalIgnoreCase))
-                    return (info.Root, info.Name);
-            }
+            var panels = ResolveAllPanels(countElements: false);
 
-            // Search runtime panels
-            foreach (var info in GetRuntimePanels())
-            {
+            // Exact match (case-insensitive)
+            foreach (var info in panels)
                 if (info.Name.Equals(panelName, StringComparison.OrdinalIgnoreCase))
                     return (info.Root, info.Name);
-            }
 
             // Partial match fallback
-            foreach (var info in GetEditorPanels())
-            {
+            foreach (var info in panels)
                 if (info.Name.IndexOf(panelName, StringComparison.OrdinalIgnoreCase) >= 0)
                     return (info.Root, info.Name);
-            }
-
-            foreach (var info in GetRuntimePanels())
-            {
-                if (info.Name.IndexOf(panelName, StringComparison.OrdinalIgnoreCase) >= 0)
-                    return (info.Root, info.Name);
-            }
 
             return (null, null);
         }
@@ -439,9 +418,10 @@ namespace UnityBridge.Tools
             public string ContextType;
             public int ElementCount;
             public VisualElement Root;
+            public string WindowType;
         }
 
-        private static List<PanelInfo> GetEditorPanels()
+        private static List<PanelInfo> GetEditorPanels(bool countElements = true)
         {
             var results = new List<PanelInfo>();
 
@@ -492,7 +472,7 @@ namespace UnityBridge.Tools
                 {
                     while (enumerator.MoveNext())
                     {
-                        ProcessPanelEntry(enumerator.Current, results);
+                        ProcessPanelEntry(enumerator.Current, results, countElements);
                     }
                 }
                 else
@@ -502,7 +482,7 @@ namespace UnityBridge.Tools
                     while ((bool)moveNextMethod.Invoke(iterator, null))
                     {
                         var kvp = currentProp.GetValue(iterator);
-                        ProcessPanelEntry(kvp, results);
+                        ProcessPanelEntry(kvp, results, countElements);
                     }
                 }
             }
@@ -514,7 +494,7 @@ namespace UnityBridge.Tools
             return results;
         }
 
-        private static void ProcessPanelEntry(object kvp, List<PanelInfo> results)
+        private static void ProcessPanelEntry(object kvp, List<PanelInfo> results, bool countElements)
         {
             if (kvp == null) return;
 
@@ -525,40 +505,86 @@ namespace UnityBridge.Tools
             if (panel == null) return;
 
             var panelType = panel.GetType();
+            var props = GetPanelProperties(panelType);
 
-            // Get contextType
-            var contextTypeProp = panelType.GetProperty("contextType",
-                BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic);
-            var contextType = contextTypeProp?.GetValue(panel)?.ToString() ?? "Unknown";
-
-            // Get visualTree
-            var visualTreeProp = panelType.GetProperty("visualTree",
-                BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic);
-            var visualTree = visualTreeProp?.GetValue(panel) as VisualElement;
+            var contextType = props.contextType?.GetValue(panel)?.ToString() ?? "Unknown";
+            var visualTree = props.visualTree?.GetValue(panel) as VisualElement;
 
             if (visualTree == null) return;
 
-            // Derive panel name from ownerObject or type
-            var ownerObjectProp = panelType.GetProperty("ownerObject",
-                BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic);
-            var ownerObject = ownerObjectProp?.GetValue(panel) as ScriptableObject;
+            var ownerObject = props.ownerObject?.GetValue(panel) as ScriptableObject;
 
-            var panelName = ownerObject != null
-                ? ownerObject.GetType().Name
-                : $"Panel_{contextType}";
+            var (panelName, windowType) = DeriveEnrichedPanelName(ownerObject, contextType);
 
-            var elementCount = CountElements(visualTree);
+            var elementCount = countElements ? CountElements(visualTree) : 0;
 
             results.Add(new PanelInfo
             {
                 Name = panelName,
                 ContextType = contextType,
                 ElementCount = elementCount,
-                Root = visualTree
+                Root = visualTree,
+                WindowType = windowType
             });
         }
 
-        private static List<PanelInfo> GetRuntimePanels()
+        private static (PropertyInfo contextType, PropertyInfo visualTree, PropertyInfo ownerObject) GetPanelProperties(Type panelType)
+        {
+            if (PanelPropCache.TryGetValue(panelType, out var cached))
+                return cached;
+
+            const BindingFlags flags = BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic;
+            var entry = (
+                contextType: panelType.GetProperty("contextType", flags),
+                visualTree: panelType.GetProperty("visualTree", flags),
+                ownerObject: panelType.GetProperty("ownerObject", flags)
+            );
+            PanelPropCache[panelType] = entry;
+            return entry;
+        }
+
+        private static (string name, string windowType) DeriveEnrichedPanelName(
+            ScriptableObject ownerObject, string contextType)
+        {
+            if (ownerObject == null)
+                return ($"Panel_{contextType}", null);
+
+            var ownerTypeName = ownerObject.GetType().Name;
+            string viewTypeName = null;
+
+            try
+            {
+                var ownerType = ownerObject.GetType();
+                if (!ActualViewPropCache.TryGetValue(ownerType, out var prop))
+                {
+                    prop = ownerType.GetProperty("actualView",
+                        BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic);
+                    ActualViewPropCache[ownerType] = prop;
+                }
+
+                if (prop != null)
+                {
+                    var view = prop.GetValue(ownerObject);
+                    if (view != null)
+                        viewTypeName = view.GetType().Name;
+                }
+            }
+            catch (TargetInvocationException ex)
+            {
+                BridgeLog.Verbose($"actualView reflection failed for {ownerTypeName}: {ex.InnerException?.GetType().Name}");
+            }
+            catch (MemberAccessException ex)
+            {
+                BridgeLog.Verbose($"actualView access denied for {ownerTypeName}: {ex.GetType().Name}");
+            }
+
+            if (viewTypeName != null)
+                return ($"{ownerTypeName}:{viewTypeName}", viewTypeName);
+
+            return (ownerTypeName, null);
+        }
+
+        private static List<PanelInfo> GetRuntimePanels(bool countElements = true)
         {
             var results = new List<PanelInfo>();
 
@@ -573,7 +599,7 @@ namespace UnityBridge.Tools
                     ? doc.panelSettings.name
                     : "Unknown";
                 var panelName = $"UIDocument {panelSettingsName} ({doc.gameObject.name})";
-                var elementCount = CountElements(doc.rootVisualElement);
+                var elementCount = countElements ? CountElements(doc.rootVisualElement) : 0;
 
                 results.Add(new PanelInfo
                 {
@@ -585,6 +611,43 @@ namespace UnityBridge.Tools
             }
 
             return results;
+        }
+
+        private static List<PanelInfo> ResolveAllPanels(bool countElements = true)
+        {
+            var panels = GetEditorPanels(countElements);
+            panels.AddRange(GetRuntimePanels(countElements));
+            DeduplicateNames(panels);
+            return panels;
+        }
+
+        private static void DeduplicateNames(List<PanelInfo> panels)
+        {
+            var nameCount = new Dictionary<string, int>(StringComparer.Ordinal);
+            foreach (var p in panels)
+            {
+                nameCount.TryGetValue(p.Name, out var count);
+                nameCount[p.Name] = count + 1;
+            }
+
+            var seen = new Dictionary<string, int>(StringComparer.Ordinal);
+            for (var i = 0; i < panels.Count; i++)
+            {
+                var name = panels[i].Name;
+                if (nameCount[name] <= 1)
+                    continue;
+
+                seen.TryGetValue(name, out var idx);
+                idx++;
+                seen[name] = idx;
+
+                if (idx >= 2)
+                {
+                    var info = panels[i];
+                    info.Name = $"{name}-{idx}";
+                    panels[i] = info;
+                }
+            }
         }
 
         #endregion

--- a/tests/test_uitree_api.py
+++ b/tests/test_uitree_api.py
@@ -6,7 +6,7 @@ from unittest.mock import MagicMock
 
 import pytest
 
-from unity_cli.api.uitree import UITreeAPI
+from unity_cli.api.uitree import UITreeAPI, _strip_panel_count
 
 
 @pytest.fixture
@@ -427,3 +427,93 @@ class TestUITreeAPIParameterIntegrity:
         mock_conn.send_request.return_value = {}
         sut.text(ref="ref_0")
         assert mock_conn.send_request.call_args[0][1]["action"] == "text"
+
+
+class TestStripPanelCount:
+    """_strip_panel_count のテスト"""
+
+    def test_dockarea_with_count(self) -> None:
+        assert _strip_panel_count("DockArea:SceneView (12)") == "DockArea:SceneView"
+
+    def test_toolbar_with_count(self) -> None:
+        assert _strip_panel_count("Toolbar (76)") == "Toolbar"
+
+    def test_no_count_suffix(self) -> None:
+        assert _strip_panel_count("Toolbar") == "Toolbar"
+
+    def test_non_numeric_parens_preserved(self) -> None:
+        assert _strip_panel_count("MyPanel (v2)") == "MyPanel (v2)"
+
+    def test_zero_count(self) -> None:
+        assert _strip_panel_count("Panel (0)") == "Panel"
+
+    def test_empty_string(self) -> None:
+        assert _strip_panel_count("") == ""
+
+
+class TestAddPanelParam:
+    """_add_panel_param が strip 済みの panel 名を送ることの確認"""
+
+    def test_strips_count_before_sending(self, sut: UITreeAPI, mock_conn: MagicMock) -> None:
+        mock_conn.send_request.return_value = {}
+
+        sut.dump(panel="DockArea:SceneView (12)")
+
+        call_args = mock_conn.send_request.call_args
+        assert call_args[0][1]["panel"] == "DockArea:SceneView"
+
+    def test_panel_without_count_unchanged(self, sut: UITreeAPI, mock_conn: MagicMock) -> None:
+        mock_conn.send_request.return_value = {}
+
+        sut.dump(panel="Toolbar")
+
+        call_args = mock_conn.send_request.call_args
+        assert call_args[0][1]["panel"] == "Toolbar"
+
+    def test_query_strips_panel_count(self, sut: UITreeAPI, mock_conn: MagicMock) -> None:
+        mock_conn.send_request.return_value = {"matches": [], "count": 0}
+
+        sut.query(panel="DockArea:InspectorWindow (896)")
+
+        call_args = mock_conn.send_request.call_args
+        assert call_args[0][1]["panel"] == "DockArea:InspectorWindow"
+
+    def test_click_strips_panel_count(self, sut: UITreeAPI, mock_conn: MagicMock) -> None:
+        mock_conn.send_request.return_value = {}
+
+        sut.click(panel="DockArea:SceneView (12)", name="Btn")
+
+        call_args = mock_conn.send_request.call_args
+        assert call_args[0][1]["panel"] == "DockArea:SceneView"
+
+    def test_scroll_strips_panel_count(self, sut: UITreeAPI, mock_conn: MagicMock) -> None:
+        mock_conn.send_request.return_value = {}
+
+        sut.scroll(panel="Toolbar (76)", name="Area")
+
+        call_args = mock_conn.send_request.call_args
+        assert call_args[0][1]["panel"] == "Toolbar"
+
+    def test_text_strips_panel_count(self, sut: UITreeAPI, mock_conn: MagicMock) -> None:
+        mock_conn.send_request.return_value = {}
+
+        sut.text(panel="DockArea:SceneView (12)", name="Label")
+
+        call_args = mock_conn.send_request.call_args
+        assert call_args[0][1]["panel"] == "DockArea:SceneView"
+
+    def test_inspect_strips_panel_count(self, sut: UITreeAPI, mock_conn: MagicMock) -> None:
+        mock_conn.send_request.return_value = {}
+
+        sut.inspect(panel="DockArea:SceneView (12)", name="Elem")
+
+        call_args = mock_conn.send_request.call_args
+        assert call_args[0][1]["panel"] == "DockArea:SceneView"
+
+    def test_none_panel_not_added(self, sut: UITreeAPI, mock_conn: MagicMock) -> None:
+        mock_conn.send_request.return_value = {}
+
+        sut.dump(panel=None)
+
+        call_args = mock_conn.send_request.call_args
+        assert "panel" not in call_args[0][1]

--- a/tests/test_uitree_format.py
+++ b/tests/test_uitree_format.py
@@ -8,8 +8,35 @@ from unity_cli.cli.commands.uitree import (
     _format_element_header,
     _format_element_style,
     _format_inspect_element,
+    _format_panel_list_entry,
     _format_query_match,
 )
+
+
+class TestFormatPanelListEntry:
+    def test_normal_panel(self) -> None:
+        panel = {"name": "Toolbar", "elementCount": 76}
+        assert _format_panel_list_entry(panel) == "Toolbar (76)"
+
+    def test_dockarea_with_window_type(self) -> None:
+        panel = {"name": "DockArea:SceneView", "elementCount": 12}
+        assert _format_panel_list_entry(panel) == "DockArea:SceneView (12)"
+
+    def test_dockarea_with_dedup_suffix(self) -> None:
+        panel = {"name": "DockArea:InspectorWindow-2", "elementCount": 896}
+        assert _format_panel_list_entry(panel) == "DockArea:InspectorWindow-2 (896)"
+
+    def test_missing_name_defaults_empty(self) -> None:
+        panel = {"elementCount": 5}
+        assert _format_panel_list_entry(panel) == " (5)"
+
+    def test_missing_count_defaults_zero(self) -> None:
+        panel = {"name": "Toolbar"}
+        assert _format_panel_list_entry(panel) == "Toolbar (0)"
+
+    def test_zero_count(self) -> None:
+        panel = {"name": "EmptyPanel", "elementCount": 0}
+        assert _format_panel_list_entry(panel) == "EmptyPanel (0)"
 
 
 class TestFormatElementHeader:

--- a/unity_cli/api/uitree.py
+++ b/unity_cli/api/uitree.py
@@ -2,10 +2,18 @@
 
 from __future__ import annotations
 
+import re
 from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
     from unity_cli.client import RelayConnection
+
+_PANEL_COUNT_RE = re.compile(r"\s+\(\d+\)$")
+
+
+def _strip_panel_count(name: str) -> str:
+    """Remove trailing `` (N)`` suffix from a panel name."""
+    return _PANEL_COUNT_RE.sub("", name)
 
 
 class UITreeAPI:
@@ -13,6 +21,10 @@ class UITreeAPI:
 
     def __init__(self, conn: RelayConnection) -> None:
         self._conn = conn
+
+    def _add_panel_param(self, params: dict[str, Any], panel: str | None) -> None:
+        if panel:
+            params["panel"] = _strip_panel_count(panel)
 
     def dump(
         self,
@@ -31,8 +43,7 @@ class UITreeAPI:
             Dictionary containing panel list or tree data.
         """
         params: dict[str, Any] = {"action": "dump", "format": format}
-        if panel:
-            params["panel"] = panel
+        self._add_panel_param(params, panel)
         if depth != -1:
             params["depth"] = depth
         return self._conn.send_request("uitree", params)
@@ -55,7 +66,8 @@ class UITreeAPI:
         Returns:
             Dictionary containing matched elements.
         """
-        params: dict[str, Any] = {"action": "query", "panel": panel}
+        params: dict[str, Any] = {"action": "query"}
+        self._add_panel_param(params, panel)
         if type:
             params["type"] = type
         if name:
@@ -91,8 +103,7 @@ class UITreeAPI:
         }
         if ref:
             params["ref"] = ref
-        if panel:
-            params["panel"] = panel
+        self._add_panel_param(params, panel)
         if name:
             params["name"] = name
         return self._conn.send_request("uitree", params)
@@ -120,8 +131,7 @@ class UITreeAPI:
         params: dict[str, Any] = {"action": "click"}
         if ref:
             params["ref"] = ref
-        if panel:
-            params["panel"] = panel
+        self._add_panel_param(params, panel)
         if name:
             params["name"] = name
         if button != 0:
@@ -155,8 +165,7 @@ class UITreeAPI:
         params: dict[str, Any] = {"action": "scroll"}
         if ref:
             params["ref"] = ref
-        if panel:
-            params["panel"] = panel
+        self._add_panel_param(params, panel)
         if name:
             params["name"] = name
         if x is not None:
@@ -186,8 +195,7 @@ class UITreeAPI:
         params: dict[str, Any] = {"action": "text"}
         if ref:
             params["ref"] = ref
-        if panel:
-            params["panel"] = panel
+        self._add_panel_param(params, panel)
         if name:
             params["name"] = name
         return self._conn.send_request("uitree", params)

--- a/unity_cli/cli/commands/uitree.py
+++ b/unity_cli/cli/commands/uitree.py
@@ -66,12 +66,8 @@ def uitree_dump(
                 print_line("[dim]No panels found[/dim]")
                 return
 
-            print_line("Panels:")
             for p in panels:
-                ctx_type = p.get("contextType", "")
-                p_name = p.get("name", "")
-                p_count = p.get("elementCount", 0)
-                print_line(f"  [{ctx_type}] {p_name} ({p_count} elements)")
+                print_line(_format_panel_list_entry(p))
 
     except UnityCLIError as e:
         _handle_error(e)
@@ -204,6 +200,13 @@ def uitree_inspect(
 # ---------------------------------------------------------------------------
 # uitree format helpers (pure functions returning list[str])
 # ---------------------------------------------------------------------------
+
+
+def _format_panel_list_entry(panel: dict[str, Any]) -> str:
+    """Format a single panel entry for pipe-friendly output."""
+    name = escape(panel.get("name", ""))
+    count = panel.get("elementCount", 0)
+    return f"{name} ({count})"
 
 
 def _format_rect_value(rect: dict[str, Any]) -> str:


### PR DESCRIPTION
## Summary
- DockArea パネルに `actualView` リフレクションで EditorWindow 型名を付与 (`DockArea` → `DockArea:SceneView` 等)
- 同名パネルに `-2`, `-3` サフィックスで重複解消
- CLI 出力をパイプフレンドリーに変更（ヘッダー・インデント・`[contextType]` プレフィックス除去、`(N elements)` → `(N)`）
- API 層で `_strip_panel_count` により `(N)` サフィックスを除去してからサーバーに送信

Closes #80

## 変更ファイル

| ファイル | 変更内容 |
|---------|---------|
| `UnityBridge/Editor/Tools/UITree.cs` | DeriveEnrichedPanelName, DeduplicateNames, ResolveAllPanels, PropertyInfo キャッシュ |
| `unity_cli/cli/commands/uitree.py` | _format_panel_list_entry, escape() 追加 |
| `unity_cli/api/uitree.py` | _strip_panel_count, _add_panel_param |
| `tests/test_uitree_format.py` | TestFormatPanelListEntry (6件) |
| `tests/test_uitree_api.py` | TestStripPanelCount (6件), TestAddPanelParam (8件) |

## Before / After

```
# Before
Panels:
  [Editor] DockArea (3 elements)
  [Editor] DockArea (3 elements)
  [Editor] DockArea (838 elements)

# After
DockArea:GameView (3)
DockArea:SceneHierarchyWindow (3)
DockArea:SceneView (838)
```

## Test plan
- [x] Python テスト 503 件全通過
- [x] pre-commit hook 全通過 (ruff, mypy, xenon, import-linter)
- [x] 手動テスト: `u uitree dump` で enriched パネル名表示を確認
- [x] 手動テスト: パイプ round-trip (`u uitree dump | head -1 | xargs ...`) 動作確認
- [x] 手動テスト: dedup サフィックス (`DockArea:InspectorWindow-2`) 動作確認

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **New Features**
  * パネル一覧表示の形式を改善。パネル名と要素数が見やすく表示されるようになりました。

* **Bug Fixes**
  * パネル検出と命名の精度を向上。重複するパネル名が自動で区別されるようになりました。
  * パネル名処理を最適化し、一貫した取得機能を実装しました。

* **Tests**
  * パネル名処理とリスト表示形式に対するテストカバレッジを大幅に拡張。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->