### PR TITLE
✨ モーダルダイアログ時のエディタブロック検知

### DIFF
--- a/UnityBridge/Editor/BridgeManager.cs
+++ b/UnityBridge/Editor/BridgeManager.cs
@@ -151,6 +151,10 @@ namespace UnityBridge
 
             // Ensure update handler is registered
             EnsureUpdateRegistered();
+
+            // Force editor to tick even when unfocused, so the command is processed immediately.
+            // Without this, EditorApplication.update stops firing when Unity loses focus.
+            EditorApplication.QueuePlayerLoopUpdate();
         }
 
         private void EnsureUpdateRegistered()

--- a/UnityBridge/Editor/EditorStateCache.cs
+++ b/UnityBridge/Editor/EditorStateCache.cs
@@ -115,9 +115,9 @@ namespace UnityBridge
             Volatile.Write(ref _lastUpdateTick, Stopwatch.GetTimestamp());
 
             // If watchdog sent editor_blocked, force re-evaluation on recovery
-            if (_blockedSent)
+            if (Volatile.Read(ref _blockedSent))
             {
-                _blockedSent = false;
+                Volatile.Write(ref _blockedSent, false);
                 _lastSentPhase = null;
                 BridgeLog.Verbose("[EditorStateCache] Main thread resumed, clearing editor_blocked");
             }
@@ -183,7 +183,7 @@ namespace UnityBridge
         /// </summary>
         private static async void OnWatchdogTick(object state)
         {
-            if (_domainReloadPending || _blockedSent) return;
+            if (_domainReloadPending || Volatile.Read(ref _blockedSent)) return;
 
             long elapsed = Stopwatch.GetTimestamp() - Volatile.Read(ref _lastUpdateTick);
             if (elapsed < BlockedThresholdTicks) return;
@@ -194,7 +194,7 @@ namespace UnityBridge
             try
             {
                 await manager.Client.SendStatusAsync(InstanceStatus.Busy, ActivityPhase.EditorBlocked);
-                _blockedSent = true;
+                Volatile.Write(ref _blockedSent, true);
                 _lastSentPhase = ActivityPhase.EditorBlocked;
                 BridgeLog.Verbose("[EditorStateCache] Main thread stall detected, sent editor_blocked");
             }

--- a/UnityBridge/Editor/EditorStateCache.cs
+++ b/UnityBridge/Editor/EditorStateCache.cs
@@ -25,7 +25,7 @@ namespace UnityBridge
 
         // Watchdog: detect main thread stall (modal dialogs, etc.)
         private static long _lastUpdateTick;
-        private static bool _blockedSent;
+        private static int _blockedSent; // 0 = not blocked, 1 = blocked (int for Interlocked)
         private static Timer _watchdogTimer;
         private const int WatchdogIntervalMs = 5000;
         private static readonly long BlockedThresholdTicks = Stopwatch.Frequency * 5; // 5 seconds
@@ -68,7 +68,7 @@ namespace UnityBridge
         /// </summary>
         public static void SetDomainReloading(bool value)
         {
-            _domainReloadPending = value;
+            Volatile.Write(ref _domainReloadPending, value);
         }
 
         /// <summary>
@@ -104,7 +104,7 @@ namespace UnityBridge
             var manager = BridgeManager.Instance;
             if (manager?.Client is not { IsConnected: true }) return;
 
-            _domainReloadPending = false;
+            Volatile.Write(ref _domainReloadPending, false);
             _lastSentPhase = null; // force re-send
             EvaluatePhase();
         }
@@ -115,9 +115,9 @@ namespace UnityBridge
             Volatile.Write(ref _lastUpdateTick, Stopwatch.GetTimestamp());
 
             // If watchdog sent editor_blocked, force re-evaluation on recovery
-            if (Volatile.Read(ref _blockedSent))
+            if (Volatile.Read(ref _blockedSent) != 0)
             {
-                Volatile.Write(ref _blockedSent, false);
+                Volatile.Write(ref _blockedSent, 0);
                 _lastSentPhase = null;
                 BridgeLog.Verbose("[EditorStateCache] Main thread resumed, clearing editor_blocked");
             }
@@ -134,7 +134,7 @@ namespace UnityBridge
 
         private static void EvaluatePhase()
         {
-            if (_domainReloadPending) return; // BridgeReloadHandler owns this state
+            if (Volatile.Read(ref _domainReloadPending)) return; // BridgeReloadHandler owns this state
 
             string phase;
             if (Tests.IsRunning)
@@ -183,23 +183,31 @@ namespace UnityBridge
         /// </summary>
         private static async void OnWatchdogTick(object state)
         {
-            if (_domainReloadPending || Volatile.Read(ref _blockedSent)) return;
+            if (Volatile.Read(ref _domainReloadPending)) return;
 
             long elapsed = Stopwatch.GetTimestamp() - Volatile.Read(ref _lastUpdateTick);
             if (elapsed < BlockedThresholdTicks) return;
 
+            // Atomically claim the right to send — prevents duplicate sends from overlapping timer ticks
+            if (Interlocked.CompareExchange(ref _blockedSent, 1, 0) != 0) return;
+
             var manager = BridgeManager.Instance;
-            if (manager?.Client is not { IsConnected: true }) return;
+            if (manager?.Client is not { IsConnected: true })
+            {
+                Volatile.Write(ref _blockedSent, 0);
+                return;
+            }
 
             try
             {
                 await manager.Client.SendStatusAsync(InstanceStatus.Busy, ActivityPhase.EditorBlocked);
-                Volatile.Write(ref _blockedSent, true);
+                _currentPhase = ActivityPhase.EditorBlocked;
                 _lastSentPhase = ActivityPhase.EditorBlocked;
                 BridgeLog.Verbose("[EditorStateCache] Main thread stall detected, sent editor_blocked");
             }
             catch (Exception ex)
             {
+                Volatile.Write(ref _blockedSent, 0);
                 BridgeLog.Warn($"[EditorStateCache] Failed to send editor_blocked: {ex.Message}");
             }
         }

--- a/UnityBridge/Editor/EditorStateCache.cs
+++ b/UnityBridge/Editor/EditorStateCache.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Diagnostics;
 using System.Reflection;
 using System.Threading;
 using UnityBridge.Helpers;
@@ -21,6 +22,13 @@ namespace UnityBridge
         private static bool _compilationEventActive;
         private static double _lastUpdateTime;
         private const double MinUpdateIntervalSeconds = 1.0;
+
+        // Watchdog: detect main thread stall (modal dialogs, etc.)
+        private static long _lastUpdateTick;
+        private static bool _blockedSent;
+        private static Timer _watchdogTimer;
+        private const int WatchdogIntervalMs = 5000;
+        private static readonly long BlockedThresholdTicks = Stopwatch.Frequency * 5; // 5 seconds
 
         private static readonly Func<bool> s_isCompiling;
 
@@ -46,6 +54,11 @@ namespace UnityBridge
 
             EditorApplication.playModeStateChanged += _ => EvaluatePhase();
             EditorApplication.update += OnUpdate;
+
+            // Watchdog timer: runs on background thread to detect main thread stalls
+            _lastUpdateTick = Stopwatch.GetTimestamp();
+            _watchdogTimer = new Timer(OnWatchdogTick, null, WatchdogIntervalMs, WatchdogIntervalMs);
+            AssemblyReloadEvents.beforeAssemblyReload += () => _watchdogTimer?.Dispose();
 
             BridgeLog.Verbose("[EditorStateCache] Initialized");
         }
@@ -98,6 +111,17 @@ namespace UnityBridge
 
         private static void OnUpdate()
         {
+            // Update tick for watchdog — must run every frame regardless of connection state
+            Volatile.Write(ref _lastUpdateTick, Stopwatch.GetTimestamp());
+
+            // If watchdog sent editor_blocked, force re-evaluation on recovery
+            if (_blockedSent)
+            {
+                _blockedSent = false;
+                _lastSentPhase = null;
+                BridgeLog.Verbose("[EditorStateCache] Main thread resumed, clearing editor_blocked");
+            }
+
             // Skip evaluation when not connected — no one to send STATUS to
             var manager = BridgeManager.Instance;
             if (manager?.Client is not { IsConnected: true }) return;
@@ -152,5 +176,32 @@ namespace UnityBridge
         }
 
         public static string CurrentPhase => _currentPhase;
+
+        /// <summary>
+        /// Background thread callback: detects when EditorApplication.update has stopped firing
+        /// (e.g. modal dialog blocking main thread) and sends STATUS "busy" with "editor_blocked".
+        /// </summary>
+        private static async void OnWatchdogTick(object state)
+        {
+            if (_domainReloadPending || _blockedSent) return;
+
+            long elapsed = Stopwatch.GetTimestamp() - Volatile.Read(ref _lastUpdateTick);
+            if (elapsed < BlockedThresholdTicks) return;
+
+            var manager = BridgeManager.Instance;
+            if (manager?.Client is not { IsConnected: true }) return;
+
+            try
+            {
+                await manager.Client.SendStatusAsync(InstanceStatus.Busy, ActivityPhase.EditorBlocked);
+                _blockedSent = true;
+                _lastSentPhase = ActivityPhase.EditorBlocked;
+                BridgeLog.Verbose("[EditorStateCache] Main thread stall detected, sent editor_blocked");
+            }
+            catch (Exception ex)
+            {
+                BridgeLog.Warn($"[EditorStateCache] Failed to send editor_blocked: {ex.Message}");
+            }
+        }
     }
 }

--- a/UnityBridge/Editor/Protocol.cs
+++ b/UnityBridge/Editor/Protocol.cs
@@ -100,6 +100,7 @@ namespace UnityBridge
         public const string RunningTests = "running_tests";
         public const string AssetImport = "asset_import";
         public const string PlaymodeTransition = "playmode_transition";
+        public const string EditorBlocked = "editor_blocked";
     }
 
     /// <summary>

--- a/relay/server.py
+++ b/relay/server.py
@@ -50,6 +50,7 @@ _VALID_DETAILS = frozenset(
         "running_tests",
         "asset_import",
         "playmode_transition",
+        "editor_blocked",
     }
 )
 _MAX_DETAIL_LEN = 64

--- a/tests/test_server_detail.py
+++ b/tests/test_server_detail.py
@@ -12,7 +12,7 @@ class TestSanitizeDetail:
 
     @pytest.mark.parametrize(
         "value",
-        ["compiling", "running_tests", "asset_import", "playmode_transition"],
+        ["compiling", "running_tests", "asset_import", "playmode_transition", "editor_blocked"],
     )
     def test_valid_detail_passes(self, value: str) -> None:
         assert _sanitize_detail(value) == value


### PR DESCRIPTION
## Summary

- Unity Editor がモーダルダイアログでブロックされている状態を検知し、CLI に通知する
- 非フォーカス時のコマンド処理遅延を改善

## Changes

- `BridgeManager`: コマンド受信時に `QueuePlayerLoopUpdate()` を呼び、非フォーカス時でもメインループを即座に発火
- `EditorStateCache`: バックグラウンド watchdog タイマー追加。`EditorApplication.update` が5秒以上停止すると STATUS `busy (editor_blocked)` を relay に送信。ダイアログ閉じ後は自動で `ready` に復帰
- `Protocol.cs`: `ActivityPhase.EditorBlocked` 定数追加
- `relay/server.py`: `_VALID_DETAILS` allowlist に `editor_blocked` 追加

## Test plan

- [x] `uv run python -m pytest tests/` 通過 (550 passed)
- [x] Unity コンパイルエラーなし
- [x] モーダルダイアログ表示中に `u instances` → `busy (editor_blocked)` 表示を確認
- [x] ダイアログ閉じ後に `ready` 自動復帰を確認

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * エディタ応答性監視（ブロック検出）を追加し、長時間応答が止まった際に状態を通知するようになりました。
  * エディタのコマンド処理タイミングを明示的に要求するようにし、ウィンドウ非フォーカス時でもコマンドが迅速に処理されます。
* **バグ修正 / 改善**
  * 「editor_blocked」状態を受け入れるようにサーバ側の状態判定を拡張しました。
* **テスト**
  * 上記状態に関するユニットテストを追加・拡充しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->