### PR TITLE
🐛 fix: heartbeat timeout の即切断を修正し BUSY メッセージを改善

### DIFF
--- a/relay/instance_registry.py
+++ b/relay/instance_registry.py
@@ -493,6 +493,9 @@ class InstanceRegistry:
         """
         Check if an instance has timed out on heartbeat.
         Returns True if the instance was disconnected due to timeout.
+
+        Note: Not called from production code — liveness is managed by
+        RelayServer._heartbeat_loop (PING/PONG + 3-retry). Retained for tests.
         """
         instance = self._instances.get(instance_id)
         if not instance:

--- a/relay/server.py
+++ b/relay/server.py
@@ -282,9 +282,10 @@ class RelayServer:
                     )
                     await self._handle_unity_message(instance, msg)
                 except TimeoutError:
-                    # Check heartbeat timeout
-                    if await self.registry.handle_heartbeat_timeout(instance_id, HEARTBEAT_TIMEOUT_MS):
-                        break
+                    # Don't disconnect here — let _heartbeat_loop handle retries via PING/PONG.
+                    # The read timeout just means no messages arrived; the heartbeat loop
+                    # independently tracks liveness with 3-retry logic.
+                    continue
         finally:
             # Cleanup
             if instance_id in self._heartbeat_tasks:
@@ -616,10 +617,11 @@ class RelayServer:
     ) -> dict[str, Any]:
         """Handle BUSY instance by enqueuing or returning error."""
         if not instance.queue_enabled:
+            detail_suffix = f" ({instance.status_detail})" if instance.status_detail else ""
             return ErrorMessage.from_code(
                 request_id,
                 ErrorCode.INSTANCE_BUSY,
-                f"Instance is busy: {instance.instance_id}. The instance is processing another command. Retry the command after a few seconds.",
+                f"Instance is busy{detail_suffix}: {instance.instance_id}. Retry the command after a few seconds.",
             ).to_dict()
 
         future: asyncio.Future[dict[str, Any]] = asyncio.Future()

--- a/unity_cli/cli/app.py
+++ b/unity_cli/cli/app.py
@@ -145,6 +145,9 @@ def main(
         config.relay_port = relay_port
     if timeout is not None:
         config.timeout = timeout
+        timeout_ms = int(timeout * 1000)
+        config.timeout_ms = timeout_ms
+        config.retry_max_time_ms = max(config.retry_max_time_ms, timeout_ms + 15000)
     if instance is not None:
         resolved = Path(instance).resolve()
         config.instance = str(resolved) if resolved.is_dir() else instance


### PR DESCRIPTION
## Summary

- #105: relay の読み取りループ TimeoutError で即座に切断していた問題を修正。heartbeat ループの3回リトライに一任
- #106: INSTANCE_BUSY エラーメッセージに `status_detail` を含めるよう改善

## Root Cause (#105)

relay に二重のタイムアウト機構があった:
1. 読み取りループ: `read_frame` が15秒タイムアウト → `handle_heartbeat_timeout` で即 DISCONNECTED
2. heartbeat ループ: PING/PONG + 3回リトライ

メカニズム1が最初のタイムアウトで即切断し、メカニズム2のリトライロジックを無効化していた。

## Test plan

- [x] pytest 550 passed
- [x] TestProject 接続 → 60秒以上維持を確認 (以前は15秒で切断)
- [x] コマンド実行正常動作を確認

Closes #105, Closes #106

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **バグ修正**
  * Unity接続のタイムアウト処理を改善し、接続の安定性を向上
  * CLIのエラーメッセージに詳細なステータス情報を追加、デバッグを容易化

<!-- end of auto-generated comment: release notes by coderabbit.ai -->