### PR TITLE
テスト基盤強化: pytest-cov導入・396テスト追加・カバレッジ62%

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -134,8 +134,20 @@ jobs:
       - name: Install dependencies
         run: uv sync
 
-      - name: Run tests
-        run: uv run pytest tests/ -v
+      - name: Run tests with coverage
+        run: >
+          uv run python -m pytest tests/ -v
+          --cov=relay --cov=unity_cli
+          --cov-report=term-missing
+          --cov-report=html:htmlcov
+          --cov-fail-under=60
+
+      - name: Upload coverage report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-report
+          path: htmlcov/
 
   build:
     runs-on: ubuntu-latest

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,7 @@ interactive = ["InquirerPy>=0.3.4"]
 dev = [
     "pytest>=8.0",
     "pytest-asyncio>=0.24",
+    "pytest-cov>=5.0",
     "mypy>=1.19.1",
     "ruff>=0.14.13",
     "pre-commit>=4.0",
@@ -46,6 +47,7 @@ dev = [
 asyncio_mode = "auto"
 markers = [
     "integration: requires running Relay Server and Unity Editor",
+    "slow: marks tests as slow (deselect with '-m \"not slow\"')",
 ]
 
 [project.urls]
@@ -105,6 +107,20 @@ strict = true
 warn_return_any = true
 warn_unused_configs = true
 disallow_untyped_defs = true
+
+[tool.coverage.run]
+source = ["relay", "unity_cli"]
+omit = ["*/tests/*", "*/test_*.py"]
+
+[tool.coverage.report]
+exclude_lines = [
+    "pragma: no cover",
+    "if TYPE_CHECKING:",
+    "if __name__ == .__main__.:",
+    "@abstractmethod",
+]
+precision = 2
+show_missing = true
 
 [tool.importlinter]
 root_packages = ["relay", "unity_cli"]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,38 @@
+"""Root test configuration.
+
+Provides shared fixtures and automatic marker assignment.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+
+@pytest.fixture
+def mock_conn() -> MagicMock:
+    """Create a bare MagicMock relay connection.
+
+    Tests that need custom return values should override this fixture
+    locally (e.g. test_dynamic_api.py).
+    """
+    return MagicMock()
+
+
+def pytest_collection_modifyitems(items: list[pytest.Item]) -> None:
+    """Auto-mark integration tests and reorder: unit first, integration last."""
+    integration_dir = Path(__file__).parent / "integration"
+
+    unit_items: list[pytest.Item] = []
+    integration_items: list[pytest.Item] = []
+
+    for item in items:
+        if Path(item.fspath).is_relative_to(integration_dir):
+            item.add_marker(pytest.mark.integration)
+            integration_items.append(item)
+        else:
+            unit_items.append(item)
+
+    items[:] = unit_items + integration_items

--- a/tests/test_asset_api.py
+++ b/tests/test_asset_api.py
@@ -1,0 +1,208 @@
+"""Tests for unity_cli/api/asset.py - Asset API"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from unity_cli.api.asset import AssetAPI
+
+
+@pytest.fixture
+def mock_conn() -> MagicMock:
+    """Create a mock relay connection."""
+    return MagicMock()
+
+
+@pytest.fixture
+def sut(mock_conn: MagicMock) -> AssetAPI:
+    """Create an AssetAPI instance with mock connection."""
+    return AssetAPI(mock_conn)
+
+
+class TestCreatePrefab:
+    """create_prefab() メソッドのテスト"""
+
+    def test_sends_asset_command(self, sut: AssetAPI, mock_conn: MagicMock) -> None:
+        """Send 'asset' as the command name."""
+        mock_conn.send_request.return_value = {}
+
+        sut.create_prefab(path="Assets/Prefabs/Obj.prefab")
+
+        assert mock_conn.send_request.call_args[0][0] == "asset"
+
+    def test_sends_create_prefab_action(self, sut: AssetAPI, mock_conn: MagicMock) -> None:
+        """Send action='create_prefab'。"""
+        mock_conn.send_request.return_value = {}
+
+        sut.create_prefab(path="Assets/Prefabs/Obj.prefab")
+
+        params = mock_conn.send_request.call_args[0][1]
+        assert params["action"] == "create_prefab"
+
+    def test_path_is_required(self, sut: AssetAPI, mock_conn: MagicMock) -> None:
+        """path パラメータが含まれる。"""
+        mock_conn.send_request.return_value = {}
+
+        sut.create_prefab(path="Assets/Prefabs/Player.prefab")
+
+        params = mock_conn.send_request.call_args[0][1]
+        assert params["path"] == "Assets/Prefabs/Player.prefab"
+
+    def test_source_included_when_set(self, sut: AssetAPI, mock_conn: MagicMock) -> None:
+        """source 指定時にパラメータに含まれる。"""
+        mock_conn.send_request.return_value = {}
+
+        sut.create_prefab(path="Assets/Prefabs/Obj.prefab", source="PlayerObj")
+
+        params = mock_conn.send_request.call_args[0][1]
+        assert params["source"] == "PlayerObj"
+
+    def test_source_excluded_when_none(self, sut: AssetAPI, mock_conn: MagicMock) -> None:
+        """source=None の場合パラメータに含まれない。"""
+        mock_conn.send_request.return_value = {}
+
+        sut.create_prefab(path="Assets/Prefabs/Obj.prefab")
+
+        params = mock_conn.send_request.call_args[0][1]
+        assert "source" not in params
+
+    def test_source_id_included_when_set(self, sut: AssetAPI, mock_conn: MagicMock) -> None:
+        """source_id 指定時にパラメータに含まれる。"""
+        mock_conn.send_request.return_value = {}
+
+        sut.create_prefab(path="Assets/Prefabs/Obj.prefab", source_id=12345)
+
+        params = mock_conn.send_request.call_args[0][1]
+        assert params["sourceId"] == 12345
+
+    def test_source_id_excluded_when_none(self, sut: AssetAPI, mock_conn: MagicMock) -> None:
+        """source_id=None の場合パラメータに含まれない。"""
+        mock_conn.send_request.return_value = {}
+
+        sut.create_prefab(path="Assets/Prefabs/Obj.prefab")
+
+        params = mock_conn.send_request.call_args[0][1]
+        assert "sourceId" not in params
+
+    def test_returns_response(self, sut: AssetAPI, mock_conn: MagicMock) -> None:
+        """send_request の戻り値をそのまま返す。"""
+        expected = {"path": "Assets/Prefabs/Obj.prefab", "guid": "abc123"}
+        mock_conn.send_request.return_value = expected
+
+        result = sut.create_prefab(path="Assets/Prefabs/Obj.prefab")
+        assert result == expected
+
+
+class TestCreateScriptableObject:
+    """create_scriptable_object() メソッドのテスト"""
+
+    def test_sends_asset_command(self, sut: AssetAPI, mock_conn: MagicMock) -> None:
+        mock_conn.send_request.return_value = {}
+
+        sut.create_scriptable_object(type_name="GameConfig", path="Assets/Data/Config.asset")
+
+        assert mock_conn.send_request.call_args[0][0] == "asset"
+
+    def test_sends_create_scriptable_object_action(self, sut: AssetAPI, mock_conn: MagicMock) -> None:
+        mock_conn.send_request.return_value = {}
+
+        sut.create_scriptable_object(type_name="GameConfig", path="Assets/Data/Config.asset")
+
+        params = mock_conn.send_request.call_args[0][1]
+        assert params["action"] == "create_scriptable_object"
+        assert params["type"] == "GameConfig"
+        assert params["path"] == "Assets/Data/Config.asset"
+
+    def test_returns_response(self, sut: AssetAPI, mock_conn: MagicMock) -> None:
+        expected = {"path": "Assets/Data/Config.asset"}
+        mock_conn.send_request.return_value = expected
+
+        result = sut.create_scriptable_object(type_name="GameConfig", path="Assets/Data/Config.asset")
+        assert result == expected
+
+
+class TestInfo:
+    """info() メソッドのテスト"""
+
+    def test_sends_asset_command(self, sut: AssetAPI, mock_conn: MagicMock) -> None:
+        mock_conn.send_request.return_value = {}
+
+        sut.info(path="Assets/Textures/icon.png")
+
+        assert mock_conn.send_request.call_args[0][0] == "asset"
+
+    def test_sends_info_action(self, sut: AssetAPI, mock_conn: MagicMock) -> None:
+        mock_conn.send_request.return_value = {}
+
+        sut.info(path="Assets/Textures/icon.png")
+
+        params = mock_conn.send_request.call_args[0][1]
+        assert params["action"] == "info"
+        assert params["path"] == "Assets/Textures/icon.png"
+
+    def test_returns_response(self, sut: AssetAPI, mock_conn: MagicMock) -> None:
+        expected = {"name": "icon", "type": "Texture2D", "guid": "def456"}
+        mock_conn.send_request.return_value = expected
+
+        result = sut.info(path="Assets/Textures/icon.png")
+        assert result == expected
+
+
+class TestDeps:
+    """deps() メソッドのテスト"""
+
+    def test_sends_deps_action(self, sut: AssetAPI, mock_conn: MagicMock) -> None:
+        mock_conn.send_request.return_value = {}
+
+        sut.deps(path="Assets/Prefabs/Player.prefab")
+
+        params = mock_conn.send_request.call_args[0][1]
+        assert params["action"] == "deps"
+        assert params["path"] == "Assets/Prefabs/Player.prefab"
+
+    def test_default_recursive_true(self, sut: AssetAPI, mock_conn: MagicMock) -> None:
+        """デフォルトで recursive=True。"""
+        mock_conn.send_request.return_value = {}
+
+        sut.deps(path="Assets/Prefabs/Player.prefab")
+
+        params = mock_conn.send_request.call_args[0][1]
+        assert params["recursive"] is True
+
+    def test_recursive_false(self, sut: AssetAPI, mock_conn: MagicMock) -> None:
+        """recursive=False を指定。"""
+        mock_conn.send_request.return_value = {}
+
+        sut.deps(path="Assets/Prefabs/Player.prefab", recursive=False)
+
+        params = mock_conn.send_request.call_args[0][1]
+        assert params["recursive"] is False
+
+    def test_returns_response(self, sut: AssetAPI, mock_conn: MagicMock) -> None:
+        expected = {"dependencies": ["Assets/Materials/Skin.mat"]}
+        mock_conn.send_request.return_value = expected
+
+        result = sut.deps(path="Assets/Prefabs/Player.prefab")
+        assert result == expected
+
+
+class TestRefs:
+    """refs() メソッドのテスト"""
+
+    def test_sends_refs_action(self, sut: AssetAPI, mock_conn: MagicMock) -> None:
+        mock_conn.send_request.return_value = {}
+
+        sut.refs(path="Assets/Materials/Skin.mat")
+
+        params = mock_conn.send_request.call_args[0][1]
+        assert params["action"] == "refs"
+        assert params["path"] == "Assets/Materials/Skin.mat"
+
+    def test_returns_response(self, sut: AssetAPI, mock_conn: MagicMock) -> None:
+        expected = {"referencers": ["Assets/Prefabs/Player.prefab"]}
+        mock_conn.send_request.return_value = expected
+
+        result = sut.refs(path="Assets/Materials/Skin.mat")
+        assert result == expected

--- a/tests/test_build_api.py
+++ b/tests/test_build_api.py
@@ -10,11 +10,6 @@ from unity_cli.api.build import BuildAPI
 
 
 @pytest.fixture
-def mock_conn() -> MagicMock:
-    return MagicMock()
-
-
-@pytest.fixture
 def sut(mock_conn: MagicMock) -> BuildAPI:
     return BuildAPI(mock_conn)
 

--- a/tests/test_client_retry.py
+++ b/tests/test_client_retry.py
@@ -1,0 +1,527 @@
+"""Tests for unity_cli/client.py - Retry logic, backoff calculation, and error classification."""
+
+from __future__ import annotations
+
+import time
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from unity_cli.client import RelayConnection
+from unity_cli.exceptions import (
+    InstanceError,
+    ProtocolError,
+    TimeoutError,
+    UnityCLIError,
+)
+
+# =============================================================================
+# Retryable Error Classification
+# =============================================================================
+
+
+class TestRetryableErrors:
+    """Test _RETRYABLE_CODES classification."""
+
+    @pytest.mark.parametrize(
+        "code",
+        ["INSTANCE_RELOADING", "INSTANCE_BUSY", "TIMEOUT", "INSTANCE_DISCONNECTED"],
+    )
+    def test_retryable_codes(self, code: str) -> None:
+        """These error codes are retryable."""
+        assert code in RelayConnection._RETRYABLE_CODES
+
+    @pytest.mark.parametrize(
+        "code",
+        [
+            "INSTANCE_NOT_FOUND",
+            "AMBIGUOUS_INSTANCE",
+            "COMMAND_NOT_FOUND",
+            "INVALID_PARAMS",
+            "INTERNAL_ERROR",
+            "PROTOCOL_ERROR",
+            "MALFORMED_JSON",
+            "PAYLOAD_TOO_LARGE",
+            "PROTOCOL_VERSION_MISMATCH",
+            "CAPABILITY_NOT_SUPPORTED",
+            "QUEUE_FULL",
+            "STALE_REF",
+        ],
+    )
+    def test_non_retryable_codes(self, code: str) -> None:
+        """These error codes are not retryable."""
+        assert code not in RelayConnection._RETRYABLE_CODES
+
+
+class TestInstanceErrorCodes:
+    """Test _INSTANCE_ERROR_CODES classification."""
+
+    @pytest.mark.parametrize(
+        "code",
+        [
+            "INSTANCE_NOT_FOUND",
+            "AMBIGUOUS_INSTANCE",
+            "INSTANCE_RELOADING",
+            "INSTANCE_BUSY",
+            "INSTANCE_DISCONNECTED",
+        ],
+    )
+    def test_instance_error_codes(self, code: str) -> None:
+        """These codes are classified as instance errors."""
+        assert code in RelayConnection._INSTANCE_ERROR_CODES
+
+
+# =============================================================================
+# Exponential Backoff
+# =============================================================================
+
+
+class TestExponentialBackoff:
+    """Test _maybe_retry backoff calculation."""
+
+    @pytest.fixture
+    def conn(self) -> RelayConnection:
+        return RelayConnection(
+            retry_initial_ms=500,
+            retry_max_ms=8000,
+            retry_max_time_ms=45000,
+        )
+
+    @pytest.mark.parametrize(
+        ("attempt", "expected_backoff"),
+        [
+            (0, 500),  # 500 * 2^0 = 500
+            (1, 1000),  # 500 * 2^1 = 1000
+            (2, 2000),  # 500 * 2^2 = 2000
+            (3, 4000),  # 500 * 2^3 = 4000
+            (4, 8000),  # 500 * 2^4 = 16000 -> capped at 8000
+            (5, 8000),  # 500 * 2^5 = 32000 -> capped at 8000
+        ],
+    )
+    def test_backoff_doubles_with_cap(self, conn: RelayConnection, attempt: int, expected_backoff: int) -> None:
+        """Backoff doubles each attempt, capped at retry_max_ms."""
+        error = InstanceError("Instance busy", "INSTANCE_BUSY")
+        sleep_ms = None
+
+        def capture_sleep(duration: float) -> None:
+            nonlocal sleep_ms
+            sleep_ms = int(duration * 1000)
+
+        with patch("time.sleep", side_effect=capture_sleep):
+            conn._maybe_retry(
+                error=error,
+                command="test",
+                elapsed_ms=0,
+                retry_initial_ms=500,
+                retry_max_ms=8000,
+                retry_max_time_ms=45000,
+                attempt=attempt,
+            )
+
+        assert sleep_ms == expected_backoff
+
+    def test_non_retryable_error_raises_immediately(self, conn: RelayConnection) -> None:
+        """Non-retryable error is re-raised without sleeping."""
+        error = InstanceError("Not found", "INSTANCE_NOT_FOUND")
+
+        with pytest.raises(InstanceError):
+            conn._maybe_retry(
+                error=error,
+                command="test",
+                elapsed_ms=0,
+                retry_initial_ms=500,
+                retry_max_ms=8000,
+                retry_max_time_ms=45000,
+                attempt=0,
+            )
+
+    def test_max_time_exceeded_raises_timeout(self, conn: RelayConnection) -> None:
+        """Raises TimeoutError when next backoff would exceed max time."""
+        error = InstanceError("Busy", "INSTANCE_BUSY")
+
+        with pytest.raises(TimeoutError, match="Max retry time would be exceeded"):
+            conn._maybe_retry(
+                error=error,
+                command="test",
+                elapsed_ms=44600,  # 44.6s elapsed
+                retry_initial_ms=500,
+                retry_max_ms=8000,
+                retry_max_time_ms=45000,
+                attempt=0,  # next backoff = 500ms, total = 45100ms > 45000ms
+            )
+
+
+# =============================================================================
+# on_retry Callback
+# =============================================================================
+
+
+class TestOnRetryCallback:
+    """Test on_retry callback invocation."""
+
+    def test_on_retry_called_with_correct_args(self) -> None:
+        """on_retry receives (code, message, attempt, backoff_ms)."""
+        callback = MagicMock()
+        conn = RelayConnection(on_retry=callback)
+
+        error = InstanceError("Reloading", "INSTANCE_RELOADING")
+
+        with patch("time.sleep"):
+            conn._maybe_retry(
+                error=error,
+                command="test",
+                elapsed_ms=0,
+                retry_initial_ms=500,
+                retry_max_ms=8000,
+                retry_max_time_ms=45000,
+                attempt=0,
+            )
+
+        callback.assert_called_once_with("INSTANCE_RELOADING", "Reloading", 1, 500)
+
+    def test_on_retry_attempt_increments(self) -> None:
+        """on_retry attempt number increments (1-indexed)."""
+        callback = MagicMock()
+        conn = RelayConnection(on_retry=callback)
+
+        error = InstanceError("Busy", "INSTANCE_BUSY")
+
+        with patch("time.sleep"):
+            conn._maybe_retry(
+                error=error,
+                command="test",
+                elapsed_ms=0,
+                retry_initial_ms=500,
+                retry_max_ms=8000,
+                retry_max_time_ms=45000,
+                attempt=2,
+            )
+
+        callback.assert_called_once_with("INSTANCE_BUSY", "Busy", 3, 2000)
+
+    def test_on_retry_not_called_when_none(self) -> None:
+        """No callback invocation when on_retry is None."""
+        conn = RelayConnection(on_retry=None)
+        error = InstanceError("Busy", "INSTANCE_BUSY")
+
+        # Should not raise AttributeError
+        with patch("time.sleep"):
+            conn._maybe_retry(
+                error=error,
+                command="test",
+                elapsed_ms=0,
+                retry_initial_ms=500,
+                retry_max_ms=8000,
+                retry_max_time_ms=45000,
+                attempt=0,
+            )
+
+
+# =============================================================================
+# send_request Retry Loop
+# =============================================================================
+
+
+class TestSendRequestRetry:
+    """Test send_request retry behavior end-to-end."""
+
+    def test_success_on_first_attempt(self) -> None:
+        """Successful first attempt returns immediately."""
+        conn = RelayConnection()
+        expected = {"isPlaying": True}
+
+        with patch.object(conn, "_send_request_once", return_value=expected):
+            actual = conn.send_request("test", {})
+
+        assert actual == expected
+
+    def test_retry_on_instance_busy_then_success(self) -> None:
+        """Retries on INSTANCE_BUSY, then succeeds."""
+        conn = RelayConnection(retry_initial_ms=1, retry_max_time_ms=5000)
+        expected = {"isPlaying": True}
+
+        call_count = 0
+
+        def fake_send_once(*args, **kwargs) -> dict:
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                raise InstanceError("Busy", "INSTANCE_BUSY")
+            return expected
+
+        with (
+            patch.object(conn, "_send_request_once", side_effect=fake_send_once),
+            patch("time.sleep"),
+        ):
+            actual = conn.send_request("test", {})
+
+        assert actual == expected
+        assert call_count == 2
+
+    def test_retry_on_instance_reloading_then_success(self) -> None:
+        """Retries on INSTANCE_RELOADING, then succeeds."""
+        conn = RelayConnection(retry_initial_ms=1, retry_max_time_ms=5000)
+        expected = {"state": "ready"}
+
+        call_count = 0
+
+        def fake_send_once(*args, **kwargs) -> dict:
+            nonlocal call_count
+            call_count += 1
+            if call_count <= 2:
+                raise InstanceError("Reloading", "INSTANCE_RELOADING")
+            return expected
+
+        with (
+            patch.object(conn, "_send_request_once", side_effect=fake_send_once),
+            patch("time.sleep"),
+        ):
+            actual = conn.send_request("test", {})
+
+        assert actual == expected
+        assert call_count == 3
+
+    def test_no_retry_on_instance_not_found(self) -> None:
+        """INSTANCE_NOT_FOUND is not retried."""
+        conn = RelayConnection()
+
+        with (
+            patch.object(
+                conn,
+                "_send_request_once",
+                side_effect=InstanceError("Not found", "INSTANCE_NOT_FOUND"),
+            ),
+            pytest.raises(InstanceError) as exc_info,
+        ):
+            conn.send_request("test", {})
+
+        assert exc_info.value.code == "INSTANCE_NOT_FOUND"
+
+    def test_no_retry_on_ambiguous_instance(self) -> None:
+        """AMBIGUOUS_INSTANCE is not retried."""
+        conn = RelayConnection()
+
+        with (
+            patch.object(
+                conn,
+                "_send_request_once",
+                side_effect=InstanceError("Ambiguous", "AMBIGUOUS_INSTANCE"),
+            ),
+            pytest.raises(InstanceError) as exc_info,
+        ):
+            conn.send_request("test", {})
+
+        assert exc_info.value.code == "AMBIGUOUS_INSTANCE"
+
+    def test_max_retry_time_exceeded(self) -> None:
+        """Raises TimeoutError when max retry time is exceeded."""
+        conn = RelayConnection(retry_initial_ms=1, retry_max_time_ms=10)
+
+        def fake_send_once(*args, **kwargs) -> None:
+            # Simulate slow responses
+            time.sleep(0.02)
+            raise InstanceError("Busy", "INSTANCE_BUSY")
+
+        with (
+            patch.object(conn, "_send_request_once", side_effect=fake_send_once),
+            pytest.raises(TimeoutError, match="Max retry time"),
+        ):
+            conn.send_request("test", {})
+
+    def test_retry_on_timeout_error(self) -> None:
+        """Retries on TIMEOUT error code."""
+        conn = RelayConnection(retry_initial_ms=1, retry_max_time_ms=5000)
+        expected = {"done": True}
+
+        call_count = 0
+
+        def fake_send_once(*args, **kwargs) -> dict:
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                raise TimeoutError("Timed out", "TIMEOUT")
+            return expected
+
+        with (
+            patch.object(conn, "_send_request_once", side_effect=fake_send_once),
+            patch("time.sleep"),
+        ):
+            actual = conn.send_request("test", {})
+
+        assert actual == expected
+        assert call_count == 2
+
+
+# =============================================================================
+# _handle_response Error Classification
+# =============================================================================
+
+
+class TestHandleResponse:
+    """Test _handle_response error classification."""
+
+    @pytest.fixture
+    def conn(self) -> RelayConnection:
+        return RelayConnection()
+
+    def test_error_response_instance_error(self, conn: RelayConnection) -> None:
+        """ERROR with instance code raises InstanceError."""
+        response = {
+            "type": "ERROR",
+            "error": {"code": "INSTANCE_NOT_FOUND", "message": "Not found"},
+        }
+
+        with pytest.raises(InstanceError) as exc_info:
+            conn._handle_response(response, "test")
+
+        assert exc_info.value.code == "INSTANCE_NOT_FOUND"
+
+    def test_error_response_timeout(self, conn: RelayConnection) -> None:
+        """ERROR with TIMEOUT code raises TimeoutError."""
+        response = {
+            "type": "ERROR",
+            "error": {"code": "TIMEOUT", "message": "Timed out"},
+        }
+
+        with pytest.raises(TimeoutError) as exc_info:
+            conn._handle_response(response, "test")
+
+        assert exc_info.value.code == "TIMEOUT"
+
+    def test_error_response_unknown_code(self, conn: RelayConnection) -> None:
+        """ERROR with unknown code raises UnityCLIError."""
+        response = {
+            "type": "ERROR",
+            "error": {"code": "SOME_NEW_ERROR", "message": "New error"},
+        }
+
+        with pytest.raises(UnityCLIError) as exc_info:
+            conn._handle_response(response, "test")
+
+        assert exc_info.value.code == "SOME_NEW_ERROR"
+
+    def test_success_response_returns_data(self, conn: RelayConnection) -> None:
+        """Successful RESPONSE returns data dict."""
+        response = {
+            "type": "RESPONSE",
+            "success": True,
+            "data": {"isPlaying": True},
+        }
+
+        actual = conn._handle_response(response, "test")
+        assert actual == {"isPlaying": True}
+
+    def test_failed_response_raises(self, conn: RelayConnection) -> None:
+        """RESPONSE with success=False raises UnityCLIError."""
+        response = {
+            "type": "RESPONSE",
+            "success": False,
+            "error": {"code": "COMMAND_FAILED", "message": "Failed"},
+        }
+
+        with pytest.raises(UnityCLIError) as exc_info:
+            conn._handle_response(response, "test")
+
+        assert exc_info.value.code == "COMMAND_FAILED"
+
+    def test_unexpected_response_type_raises_protocol_error(self, conn: RelayConnection) -> None:
+        """Unexpected message type raises ProtocolError."""
+        response = {"type": "UNKNOWN", "data": {}}
+
+        with pytest.raises(ProtocolError):
+            conn._handle_response(response, "test")
+
+    def test_instances_response_returns_data(self, conn: RelayConnection) -> None:
+        """INSTANCES response returns data dict."""
+        response = {
+            "type": "INSTANCES",
+            "data": {"instances": [{"instance_id": "/test", "status": "ready"}]},
+        }
+
+        actual = conn._handle_response(response, "test")
+        assert "instances" in actual
+
+
+# =============================================================================
+# Version Info Callback
+# =============================================================================
+
+
+class TestVersionInfoCallback:
+    """Test on_version_info callback behavior."""
+
+    def test_version_info_called_once(self) -> None:
+        """on_version_info is called only once on first success."""
+        callback = MagicMock()
+        conn = RelayConnection(on_version_info=callback)
+
+        response = {
+            "type": "RESPONSE",
+            "success": True,
+            "data": {},
+            "relay_version": "1.0.0",
+            "bridge_version": "2.0.0",
+        }
+
+        conn._handle_response(response, "test")
+        conn._handle_response(response, "test")
+
+        callback.assert_called_once_with("1.0.0", "2.0.0")
+
+    def test_version_info_not_called_without_versions(self) -> None:
+        """on_version_info not called when versions are empty."""
+        callback = MagicMock()
+        conn = RelayConnection(on_version_info=callback)
+
+        response = {
+            "type": "RESPONSE",
+            "success": True,
+            "data": {},
+        }
+
+        conn._handle_response(response, "test")
+
+        callback.assert_not_called()
+
+
+# =============================================================================
+# Connection Defaults
+# =============================================================================
+
+
+class TestConnectionDefaults:
+    """Test RelayConnection default values."""
+
+    def test_default_host_and_port(self) -> None:
+        """Default host and port match config constants."""
+        conn = RelayConnection()
+        assert conn.host == "127.0.0.1"
+        assert conn.port == 6500
+
+    def test_default_retry_params(self) -> None:
+        """Default retry parameters match documented values."""
+        conn = RelayConnection()
+        assert conn.retry_initial_ms == 500
+        assert conn.retry_max_ms == 8000
+        assert conn.retry_max_time_ms == 30000
+
+    def test_custom_retry_params(self) -> None:
+        """Custom retry parameters are stored correctly."""
+        conn = RelayConnection(
+            retry_initial_ms=1000,
+            retry_max_ms=16000,
+            retry_max_time_ms=60000,
+        )
+        assert conn.retry_initial_ms == 1000
+        assert conn.retry_max_ms == 16000
+        assert conn.retry_max_time_ms == 60000
+
+    def test_client_id_generated(self) -> None:
+        """Client ID is auto-generated."""
+        conn = RelayConnection()
+        assert len(conn._client_id) == 12
+
+    def test_instance_parameter(self) -> None:
+        """Instance parameter is stored."""
+        conn = RelayConnection(instance="/path/to/project")
+        assert conn.instance == "/path/to/project"

--- a/tests/test_cmd_project.py
+++ b/tests/test_cmd_project.py
@@ -1,0 +1,146 @@
+"""Tests for unity_cli/cli/commands/project.py - Project CLI Commands
+
+project サブコマンドは Relay 不要（ファイルベース）なので、
+CliRunner でテストしやすい。ただし、main callback が UnityClient を
+生成しようとするため、relay_host へ接続不要な project コマンドでも
+callback を通る必要がある。ここでは UnityClient を mock に差し替えて
+テストする。
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+from typer.testing import CliRunner
+
+from unity_cli.cli.app import app
+
+runner = CliRunner()
+
+
+@pytest.fixture
+def unity_project(tmp_path: Path) -> Path:
+    """最小限の Unity プロジェクト構造を作成。"""
+    (tmp_path / "Assets").mkdir()
+    ps = tmp_path / "ProjectSettings"
+    ps.mkdir()
+
+    (ps / "ProjectVersion.txt").write_text(
+        "m_EditorVersion: 2022.3.10f1\nm_EditorVersionWithRevision: 2022.3.10f1 (abc123)\n"
+    )
+    (ps / "ProjectSettings.asset").write_text(
+        "productName: TestGame\n"
+        "companyName: TestCo\n"
+        "bundleVersion: 1.2.3\n"
+        "defaultScreenWidth: 1920\n"
+        "defaultScreenHeight: 1080\n"
+    )
+
+    pkgs = tmp_path / "Packages"
+    pkgs.mkdir()
+    (pkgs / "manifest.json").write_text(
+        json.dumps(
+            {
+                "dependencies": {
+                    "com.unity.textmeshpro": "3.0.6",
+                    "com.example.local": "file:../local-pkg",
+                    "com.unity.modules.audio": "1.0.0",
+                }
+            }
+        )
+    )
+
+    return tmp_path
+
+
+def _invoke(args: list[str]) -> object:
+    """UnityClient の生成を mock してから CliRunner.invoke を実行。
+
+    main callback 内で `from unity_cli.client import UnityClient` が
+    ローカル import されるため、unity_cli.client.UnityClient を patch する。
+    """
+    with patch("unity_cli.client.UnityClient", return_value=MagicMock()):
+        return runner.invoke(app, args)
+
+
+class TestProjectVersion:
+    """project version コマンドのテスト"""
+
+    def test_shows_version(self, unity_project: Path) -> None:
+        """Unity バージョンが表示される。"""
+        result = _invoke(["project", "version", str(unity_project)])
+        assert result.exit_code == 0
+        assert "2022.3.10f1" in result.output
+
+    def test_json_output(self, unity_project: Path) -> None:
+        """--json でJSON形式の出力。"""
+        result = _invoke(["project", "version", str(unity_project), "--json"])
+        assert result.exit_code == 0
+        data = json.loads(result.output)
+        assert data["version"] == "2022.3.10f1"
+        assert data["revision"] == "abc123"
+
+    def test_invalid_path(self, tmp_path: Path) -> None:
+        """無効なパスでエラー。"""
+        result = _invoke(["project", "version", str(tmp_path)])
+        assert result.exit_code != 0
+
+
+class TestProjectInfo:
+    """project info コマンドのテスト"""
+
+    def test_shows_info(self, unity_project: Path) -> None:
+        """プロジェクト情報が表示される。"""
+        result = _invoke(["project", "info", str(unity_project)])
+        assert result.exit_code == 0
+        assert "TestGame" in result.output
+        assert "TestCo" in result.output
+
+    def test_json_output(self, unity_project: Path) -> None:
+        """--json でJSON形式の出力。"""
+        result = _invoke(["project", "info", str(unity_project), "--json"])
+        assert result.exit_code == 0
+        data = json.loads(result.output)
+        assert data["product_name"] == "TestGame"
+        assert data["unity_version"] == "2022.3.10f1"
+
+    def test_invalid_path(self, tmp_path: Path) -> None:
+        """無効なパスでエラー。"""
+        result = _invoke(["project", "info", str(tmp_path)])
+        assert result.exit_code != 0
+
+
+class TestProjectPackages:
+    """project packages コマンドのテスト"""
+
+    def test_lists_packages(self, unity_project: Path) -> None:
+        """パッケージ一覧が表示される。"""
+        result = _invoke(["project", "packages", str(unity_project)])
+        assert result.exit_code == 0
+        assert "textmeshpro" in result.output
+
+    def test_json_output(self, unity_project: Path) -> None:
+        """--json でJSON形式の出力。"""
+        result = _invoke(["project", "packages", str(unity_project), "--json"])
+        assert result.exit_code == 0
+        data = json.loads(result.output)
+        names = [pkg["name"] for pkg in data]
+        assert "com.unity.textmeshpro" in names
+        # modules はデフォルトで除外
+        assert "com.unity.modules.audio" not in names
+
+    def test_include_modules(self, unity_project: Path) -> None:
+        """--include-modules でモジュールも含まれる。"""
+        result = _invoke(["project", "packages", str(unity_project), "--include-modules", "--json"])
+        assert result.exit_code == 0
+        data = json.loads(result.output)
+        names = [pkg["name"] for pkg in data]
+        assert "com.unity.modules.audio" in names
+
+    def test_invalid_path(self, tmp_path: Path) -> None:
+        """無効なパスでエラー。"""
+        result = _invoke(["project", "packages", str(tmp_path)])
+        assert result.exit_code != 0

--- a/tests/test_cmd_screenshot.py
+++ b/tests/test_cmd_screenshot.py
@@ -1,0 +1,123 @@
+"""Tests for unity_cli/cli/commands/screenshot.py - Screenshot CLI Command
+
+screenshot コマンドは Relay 経由で Unity Editor に接続するため、
+UnityClient を mock に差し替えてテストする。
+"""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import MagicMock, patch
+
+from typer.testing import CliRunner
+
+from unity_cli.cli.app import app
+
+runner = CliRunner()
+
+
+def _make_mock_client(screenshot_return: dict | None = None) -> MagicMock:
+    """screenshot API の戻り値を設定した mock client を生成。"""
+    client = MagicMock()
+    client.screenshot.capture.return_value = screenshot_return or {
+        "message": "Screenshot captured",
+        "path": "/tmp/screenshot.png",
+        "source": "game",
+    }
+    client.screenshot.burst.return_value = screenshot_return or {
+        "frameCount": 10,
+        "outputDir": "/tmp/burst",
+        "format": "jpg",
+        "elapsed": 1.5,
+        "fps": 6.67,
+    }
+    return client
+
+
+def _invoke(args: list[str], client: MagicMock | None = None) -> object:
+    """UnityClient を mock して CliRunner.invoke を実行。"""
+    mock_client = client or _make_mock_client()
+    with patch("unity_cli.client.UnityClient", return_value=mock_client):
+        return runner.invoke(app, args)
+
+
+class TestScreenshotCapture:
+    """screenshot (capture mode) のテスト"""
+
+    def test_default_capture(self) -> None:
+        """デフォルトのキャプチャが成功する。"""
+        result = _invoke(["screenshot"])
+        assert result.exit_code == 0
+
+    def test_capture_calls_api(self) -> None:
+        """API が正しく呼ばれる。"""
+        client = _make_mock_client()
+        _invoke(["screenshot", "-s", "game"], client)
+        client.screenshot.capture.assert_called_once()
+
+    def test_capture_with_source_scene(self) -> None:
+        """--source scene が API に渡される。"""
+        client = _make_mock_client()
+        _invoke(["screenshot", "-s", "scene"], client)
+        call_kwargs = client.screenshot.capture.call_args
+        assert call_kwargs.kwargs.get("source") == "scene" or (call_kwargs.args and call_kwargs.args[0] == "scene")
+
+    def test_capture_json_output(self) -> None:
+        """--json でJSON形式の出力。"""
+        result = _invoke(["screenshot", "--json"])
+        assert result.exit_code == 0
+        data = json.loads(result.output)
+        assert "path" in data
+
+    def test_capture_with_path_option(self) -> None:
+        """--path オプションが API に渡される。"""
+        client = _make_mock_client()
+        _invoke(["screenshot", "-p", "/tmp/out.png"], client)
+        client.screenshot.capture.assert_called_once()
+        kwargs = client.screenshot.capture.call_args[1]
+        assert kwargs.get("path") == "/tmp/out.png"
+
+    def test_invalid_source(self) -> None:
+        """不正な source でエラー終了。"""
+        result = _invoke(["screenshot", "-s", "invalid_source"])
+        assert result.exit_code != 0
+
+    def test_invalid_format(self) -> None:
+        """不正な format でエラー終了。"""
+        result = _invoke(["screenshot", "-f", "bmp"])
+        assert result.exit_code != 0
+
+
+class TestScreenshotBurst:
+    """screenshot --burst のテスト"""
+
+    def test_burst_mode(self) -> None:
+        """--burst でバーストキャプチャが成功する。"""
+        result = _invoke(["screenshot", "--burst"])
+        assert result.exit_code == 0
+
+    def test_burst_calls_burst_api(self) -> None:
+        """--burst で burst API が呼ばれる。"""
+        client = _make_mock_client()
+        _invoke(["screenshot", "--burst"], client)
+        client.screenshot.burst.assert_called_once()
+        client.screenshot.capture.assert_not_called()
+
+    def test_burst_json_output(self) -> None:
+        """--burst --json でJSON形式の出力。"""
+        result = _invoke(["screenshot", "--burst", "--json"])
+        assert result.exit_code == 0
+        data = json.loads(result.output)
+        assert "frameCount" in data
+
+    def test_burst_with_count(self) -> None:
+        """--count オプションが API に渡される。"""
+        client = _make_mock_client()
+        _invoke(["screenshot", "--burst", "-n", "50"], client)
+        kwargs = client.screenshot.burst.call_args[1]
+        assert kwargs.get("count") == 50
+
+    def test_burst_invalid_format(self) -> None:
+        """--burst + 不正な format でエラー終了。"""
+        result = _invoke(["screenshot", "--burst", "-f", "gif"])
+        assert result.exit_code != 0

--- a/tests/test_component_api.py
+++ b/tests/test_component_api.py
@@ -10,11 +10,6 @@ from unity_cli.api.component import ComponentAPI
 
 
 @pytest.fixture
-def mock_conn() -> MagicMock:
-    return MagicMock()
-
-
-@pytest.fixture
 def sut(mock_conn: MagicMock) -> ComponentAPI:
     return ComponentAPI(mock_conn)
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,254 @@
+"""Tests for unity_cli/config.py - Configuration Module"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from pydantic import ValidationError
+
+from unity_cli.config import (
+    CONFIG_FILE_NAME,
+    DEFAULT_RELAY_HOST,
+    DEFAULT_RELAY_PORT,
+    DEFAULT_TIMEOUT_MS,
+    HEADER_SIZE,
+    MAX_PAYLOAD_BYTES,
+    PROTOCOL_VERSION,
+    UnityCLIConfig,
+)
+
+
+class TestProtocolConstants:
+    """プロトコル定数の確認"""
+
+    def test_protocol_version(self) -> None:
+        assert PROTOCOL_VERSION == "1.0"
+
+    def test_default_relay_host(self) -> None:
+        assert DEFAULT_RELAY_HOST == "127.0.0.1"
+
+    def test_default_relay_port(self) -> None:
+        assert DEFAULT_RELAY_PORT == 6500
+
+    def test_header_size(self) -> None:
+        assert HEADER_SIZE == 4
+
+    def test_max_payload_bytes(self) -> None:
+        assert MAX_PAYLOAD_BYTES == 16 * 1024 * 1024
+
+    def test_default_timeout_ms(self) -> None:
+        assert DEFAULT_TIMEOUT_MS == 30000
+
+    def test_config_file_name(self) -> None:
+        assert CONFIG_FILE_NAME == ".unity-cli.toml"
+
+
+class TestUnityCLIConfigDefaults:
+    """UnityCLIConfig デフォルト値のテスト"""
+
+    def test_default_relay_host(self) -> None:
+        sut = UnityCLIConfig()
+        assert sut.relay_host == "127.0.0.1"
+
+    def test_default_relay_port(self) -> None:
+        sut = UnityCLIConfig()
+        assert sut.relay_port == 6500
+
+    def test_default_timeout(self) -> None:
+        sut = UnityCLIConfig()
+        assert sut.timeout == 15.0
+
+    def test_default_timeout_ms(self) -> None:
+        sut = UnityCLIConfig()
+        assert sut.timeout_ms == 30000
+
+    def test_default_instance_is_none(self) -> None:
+        sut = UnityCLIConfig()
+        assert sut.instance is None
+
+    def test_default_retry_initial_ms(self) -> None:
+        sut = UnityCLIConfig()
+        assert sut.retry_initial_ms == 500
+
+    def test_default_retry_max_ms(self) -> None:
+        sut = UnityCLIConfig()
+        assert sut.retry_max_ms == 8000
+
+    def test_default_retry_max_time_ms(self) -> None:
+        sut = UnityCLIConfig()
+        assert sut.retry_max_time_ms == 45000
+
+
+class TestUnityCLIConfigValidation:
+    """UnityCLIConfig バリデーションのテスト"""
+
+    @pytest.mark.parametrize(
+        "port",
+        [0, -1, 65536, 100000],
+        ids=["zero", "negative", "65536", "large"],
+    )
+    def test_invalid_relay_port(self, port: int) -> None:
+        """範囲外のポート番号は ValidationError。"""
+        with pytest.raises(ValidationError):
+            UnityCLIConfig(relay_port=port)
+
+    @pytest.mark.parametrize(
+        "port",
+        [1, 6500, 65535],
+        ids=["min", "default", "max"],
+    )
+    def test_valid_relay_port(self, port: int) -> None:
+        """有効なポート番号。"""
+        sut = UnityCLIConfig(relay_port=port)
+        assert sut.relay_port == port
+
+    def test_timeout_must_be_positive(self) -> None:
+        with pytest.raises(ValidationError):
+            UnityCLIConfig(timeout=0)
+
+    def test_timeout_ms_must_be_positive(self) -> None:
+        with pytest.raises(ValidationError):
+            UnityCLIConfig(timeout_ms=0)
+
+    def test_retry_initial_ms_must_be_positive(self) -> None:
+        with pytest.raises(ValidationError):
+            UnityCLIConfig(retry_initial_ms=0)
+
+    def test_retry_max_ms_must_be_positive(self) -> None:
+        with pytest.raises(ValidationError):
+            UnityCLIConfig(retry_max_ms=0)
+
+    def test_retry_max_time_ms_must_be_positive(self) -> None:
+        with pytest.raises(ValidationError):
+            UnityCLIConfig(retry_max_time_ms=0)
+
+    def test_extra_fields_ignored(self) -> None:
+        """extra='ignore' により未知フィールドは無視。"""
+        sut = UnityCLIConfig(unknown_field="value")  # type: ignore[call-arg]
+        assert not hasattr(sut, "unknown_field")
+
+    def test_validate_assignment(self) -> None:
+        """validate_assignment=True: 代入時もバリデーション。"""
+        sut = UnityCLIConfig()
+        with pytest.raises(ValidationError):
+            sut.relay_port = 0
+
+
+class TestUnityCLIConfigLoad:
+    """UnityCLIConfig.load() のテスト"""
+
+    def test_load_from_toml_file(self, tmp_path: Path) -> None:
+        """TOML ファイルから設定を読み込む。"""
+        config_file = tmp_path / CONFIG_FILE_NAME
+        config_file.write_text('relay_host = "192.168.1.100"\nrelay_port = 7000\ntimeout = 30.0\ntimeout_ms = 60000\n')
+
+        sut = UnityCLIConfig.load(config_file)
+
+        assert sut.relay_host == "192.168.1.100"
+        assert sut.relay_port == 7000
+        assert sut.timeout == 30.0
+        assert sut.timeout_ms == 60000
+
+    def test_load_partial_toml(self, tmp_path: Path) -> None:
+        """部分的な TOML ファイルは指定分だけ上書き、残りはデフォルト。"""
+        config_file = tmp_path / CONFIG_FILE_NAME
+        config_file.write_text("relay_port = 9999\n")
+
+        sut = UnityCLIConfig.load(config_file)
+
+        assert sut.relay_port == 9999
+        assert sut.relay_host == DEFAULT_RELAY_HOST  # default
+
+    def test_load_nonexistent_file_returns_defaults(self) -> None:
+        """存在しないファイルパスはデフォルト値を返す。"""
+        sut = UnityCLIConfig.load(Path("/nonexistent/path/config.toml"))
+        assert sut.relay_host == DEFAULT_RELAY_HOST
+        assert sut.relay_port == DEFAULT_RELAY_PORT
+
+    def test_load_none_returns_defaults(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """config_path=None かつ _find_config_file が None を返す場合、デフォルト。"""
+        monkeypatch.setattr(UnityCLIConfig, "_find_config_file", classmethod(lambda cls: None))
+        sut = UnityCLIConfig.load(None)
+        assert sut.relay_port == DEFAULT_RELAY_PORT
+
+    def test_load_invalid_toml_returns_defaults(self, tmp_path: Path) -> None:
+        """不正な TOML ファイルはデフォルト値を返す。"""
+        config_file = tmp_path / CONFIG_FILE_NAME
+        config_file.write_text("this is not valid toml {{{{")
+
+        sut = UnityCLIConfig.load(config_file)
+
+        assert sut.relay_port == DEFAULT_RELAY_PORT
+
+    def test_load_with_instance(self, tmp_path: Path) -> None:
+        """instance フィールドの読み込み。"""
+        config_file = tmp_path / CONFIG_FILE_NAME
+        config_file.write_text('instance = "/path/to/project"\n')
+
+        sut = UnityCLIConfig.load(config_file)
+
+        assert sut.instance == "/path/to/project"
+
+    def test_load_extra_fields_ignored(self, tmp_path: Path) -> None:
+        """未知フィールドは無視される。"""
+        config_file = tmp_path / CONFIG_FILE_NAME
+        config_file.write_text('some_unknown = "value"\nrelay_port = 8000\n')
+
+        sut = UnityCLIConfig.load(config_file)
+
+        assert sut.relay_port == 8000
+
+
+class TestUnityCLIConfigToToml:
+    """UnityCLIConfig.to_toml() のテスト"""
+
+    def test_to_toml_contains_all_fields(self) -> None:
+        """生成される TOML に全フィールドが含まれる。"""
+        sut = UnityCLIConfig()
+        toml_str = sut.to_toml()
+
+        assert 'relay_host = "127.0.0.1"' in toml_str
+        assert "relay_port = 6500" in toml_str
+        assert "timeout = 15.0" in toml_str
+        assert "timeout_ms = 30000" in toml_str
+        assert "retry_initial_ms = 500" in toml_str
+        assert "retry_max_ms = 8000" in toml_str
+        assert "retry_max_time_ms = 45000" in toml_str
+
+    def test_to_toml_instance_not_set(self) -> None:
+        """instance=None の場合 '# not set' がコメント出力される。"""
+        sut = UnityCLIConfig()
+        toml_str = sut.to_toml()
+        assert "instance = # not set" in toml_str
+
+    def test_to_toml_instance_set(self) -> None:
+        """instance が設定されている場合、引用符付きで出力。"""
+        sut = UnityCLIConfig(instance="/my/project")
+        toml_str = sut.to_toml()
+        assert 'instance = "/my/project"' in toml_str
+
+    def test_to_toml_roundtrip(self, tmp_path: Path) -> None:
+        """to_toml で書き出した文字列を load で読み込み、値が一致する。"""
+        original = UnityCLIConfig(
+            relay_host="10.0.0.1",
+            relay_port=7777,
+            timeout=20.0,
+            timeout_ms=50000,
+            instance="/project",
+            retry_initial_ms=1000,
+            retry_max_ms=16000,
+            retry_max_time_ms=90000,
+        )
+        config_file = tmp_path / CONFIG_FILE_NAME
+        config_file.write_text(original.to_toml())
+
+        loaded = UnityCLIConfig.load(config_file)
+
+        assert loaded.relay_host == original.relay_host
+        assert loaded.relay_port == original.relay_port
+        assert loaded.timeout == original.timeout
+        assert loaded.timeout_ms == original.timeout_ms
+        assert loaded.retry_initial_ms == original.retry_initial_ms
+        assert loaded.retry_max_ms == original.retry_max_ms
+        assert loaded.retry_max_time_ms == original.retry_max_time_ms

--- a/tests/test_console_api.py
+++ b/tests/test_console_api.py
@@ -10,12 +10,6 @@ from unity_cli.api.console import ConsoleAPI
 
 
 @pytest.fixture
-def mock_conn() -> MagicMock:
-    """Create a mock relay connection."""
-    return MagicMock()
-
-
-@pytest.fixture
 def sut(mock_conn: MagicMock) -> ConsoleAPI:
     """Create a ConsoleAPI instance with mock connection."""
     return ConsoleAPI(mock_conn)

--- a/tests/test_editor_api.py
+++ b/tests/test_editor_api.py
@@ -10,12 +10,6 @@ from unity_cli.api.editor import EditorAPI
 
 
 @pytest.fixture
-def mock_conn() -> MagicMock:
-    """Create a mock relay connection."""
-    return MagicMock()
-
-
-@pytest.fixture
 def sut(mock_conn: MagicMock) -> EditorAPI:
     """Create an EditorAPI instance with mock connection."""
     return EditorAPI(mock_conn)

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -1,0 +1,134 @@
+"""Tests for unity_cli/exceptions.py - Exception Hierarchy"""
+
+from __future__ import annotations
+
+import pytest
+
+from unity_cli.exceptions import (
+    ConnectionError,
+    EditorNotFoundError,
+    HubError,
+    HubInstallError,
+    HubNotFoundError,
+    InstanceError,
+    ProjectError,
+    ProjectVersionError,
+    ProtocolError,
+    TimeoutError,
+    UnityCLIError,
+)
+
+
+class TestUnityCLIError:
+    """UnityCLIError 基底クラスのテスト"""
+
+    def test_message_only(self) -> None:
+        """メッセージのみ指定時、code は None。"""
+        sut = UnityCLIError("something went wrong")
+        assert sut.message == "something went wrong"
+        assert sut.code is None
+
+    def test_message_with_code(self) -> None:
+        """メッセージとコードの両方を指定。"""
+        sut = UnityCLIError("fail", code="E001")
+        assert sut.message == "fail"
+        assert sut.code == "E001"
+
+    def test_str_without_code(self) -> None:
+        """code なしの str 表現はメッセージのみ。"""
+        sut = UnityCLIError("plain message")
+        assert str(sut) == "plain message"
+
+    def test_str_with_code(self) -> None:
+        """code ありの str 表現は [code] message 形式。"""
+        sut = UnityCLIError("detail", code="ERR_X")
+        assert str(sut) == "[ERR_X] detail"
+
+    def test_is_exception(self) -> None:
+        """Exception を継承している。"""
+        assert issubclass(UnityCLIError, Exception)
+
+    def test_can_be_raised_and_caught(self) -> None:
+        """raise/except で動作する。"""
+        with pytest.raises(UnityCLIError, match="test"):
+            raise UnityCLIError("test")
+
+
+class TestInheritanceHierarchy:
+    """例外クラスの継承階層テスト"""
+
+    @pytest.mark.parametrize(
+        ("child", "parent"),
+        [
+            (ConnectionError, UnityCLIError),
+            (ProtocolError, UnityCLIError),
+            (InstanceError, UnityCLIError),
+            (TimeoutError, UnityCLIError),
+            (HubError, UnityCLIError),
+            (HubNotFoundError, HubError),
+            (HubInstallError, HubError),
+            (ProjectError, UnityCLIError),
+            (ProjectVersionError, ProjectError),
+            (EditorNotFoundError, ProjectError),
+        ],
+    )
+    def test_subclass_relationship(self, child: type, parent: type) -> None:
+        """各例外は正しい親クラスを継承。"""
+        assert issubclass(child, parent)
+
+    @pytest.mark.parametrize(
+        "exc_cls",
+        [
+            ConnectionError,
+            ProtocolError,
+            InstanceError,
+            TimeoutError,
+            HubError,
+            HubNotFoundError,
+            HubInstallError,
+            ProjectError,
+            ProjectVersionError,
+            EditorNotFoundError,
+        ],
+    )
+    def test_all_inherit_from_base(self, exc_cls: type) -> None:
+        """全例外が UnityCLIError を継承。"""
+        assert issubclass(exc_cls, UnityCLIError)
+
+
+class TestSubclassBehavior:
+    """サブクラスが UnityCLIError の振る舞いを継承するテスト"""
+
+    @pytest.mark.parametrize(
+        ("exc_cls", "code"),
+        [
+            (ConnectionError, "CONN_REFUSED"),
+            (ProtocolError, "PROTOCOL_ERR"),
+            (InstanceError, "INSTANCE_NOT_FOUND"),
+            (TimeoutError, "TIMEOUT"),
+            (HubNotFoundError, "HUB_NOT_FOUND"),
+            (HubInstallError, "HUB_INSTALL_FAILED"),
+            (ProjectVersionError, "PROJECT_VERSION_NOT_FOUND"),
+            (EditorNotFoundError, "EDITOR_NOT_FOUND"),
+        ],
+    )
+    def test_subclass_with_code(self, exc_cls: type[UnityCLIError], code: str) -> None:
+        """サブクラスも code 付きで生成可能。"""
+        sut = exc_cls("msg", code=code)
+        assert sut.code == code
+        assert str(sut) == f"[{code}] msg"
+
+    def test_catch_hub_error_catches_hub_not_found(self) -> None:
+        """HubError で catch すると HubNotFoundError もキャッチされる。"""
+        with pytest.raises(HubError):
+            raise HubNotFoundError("hub missing", code="HUB_NOT_FOUND")
+
+    def test_catch_project_error_catches_version_error(self) -> None:
+        """ProjectError で catch すると ProjectVersionError もキャッチされる。"""
+        with pytest.raises(ProjectError):
+            raise ProjectVersionError("version file missing")
+
+    def test_catch_base_catches_all(self) -> None:
+        """UnityCLIError で catch すると全サブクラスをキャッチ。"""
+        with pytest.raises(UnityCLIError):
+            raise EditorNotFoundError("not installed")

--- a/tests/test_gameobject_api.py
+++ b/tests/test_gameobject_api.py
@@ -10,11 +10,6 @@ from unity_cli.api.gameobject import GameObjectAPI
 
 
 @pytest.fixture
-def mock_conn() -> MagicMock:
-    return MagicMock()
-
-
-@pytest.fixture
 def sut(mock_conn: MagicMock) -> GameObjectAPI:
     return GameObjectAPI(mock_conn)
 

--- a/tests/test_hub.py
+++ b/tests/test_hub.py
@@ -1,0 +1,638 @@
+"""Tests for unity_cli/hub/ - Hub Package (paths, project, hub_cli, interactive)"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+from unity_cli.exceptions import (
+    HubInstallError,
+    HubNotFoundError,
+    ProjectError,
+    ProjectVersionError,
+)
+from unity_cli.hub.hub_cli import HubCLI
+from unity_cli.hub.interactive import is_tty, prompt_confirm, prompt_editor_selection
+from unity_cli.hub.paths import InstalledEditor, PlatformPaths
+from unity_cli.hub.project import (
+    AssemblyDefinition,
+    BuildScene,
+    BuildSettings,
+    PackageManifest,
+    ProjectInfo,
+    ProjectSettings,
+    ProjectVersion,
+    QualitySettings,
+    TagLayerSettings,
+    find_assembly_definitions,
+    is_unity_project,
+)
+
+# =============================================================================
+# ProjectVersion
+# =============================================================================
+
+
+class TestProjectVersion:
+    """ProjectVersion のテスト"""
+
+    def test_from_file_basic(self, tmp_path: Path) -> None:
+        """基本的な ProjectVersion.txt のパース。"""
+        (tmp_path / "ProjectSettings").mkdir()
+        version_file = tmp_path / "ProjectSettings" / "ProjectVersion.txt"
+        version_file.write_text("m_EditorVersion: 2022.3.10f1\n")
+
+        sut = ProjectVersion.from_file(tmp_path)
+
+        assert sut.version == "2022.3.10f1"
+        assert sut.revision is None
+
+    def test_from_file_with_revision(self, tmp_path: Path) -> None:
+        """revision 情報付きのパース。"""
+        (tmp_path / "ProjectSettings").mkdir()
+        version_file = tmp_path / "ProjectSettings" / "ProjectVersion.txt"
+        version_file.write_text("m_EditorVersion: 2022.3.10f1\nm_EditorVersionWithRevision: 2022.3.10f1 (abc123def)\n")
+
+        sut = ProjectVersion.from_file(tmp_path)
+
+        assert sut.version == "2022.3.10f1"
+        assert sut.revision == "abc123def"
+
+    def test_from_file_missing_raises(self, tmp_path: Path) -> None:
+        """ファイルが存在しない場合 ProjectVersionError。"""
+        with pytest.raises(ProjectVersionError, match="not found"):
+            ProjectVersion.from_file(tmp_path)
+
+    def test_from_file_invalid_format_raises(self, tmp_path: Path) -> None:
+        """m_EditorVersion が含まれない不正フォーマット。"""
+        (tmp_path / "ProjectSettings").mkdir()
+        version_file = tmp_path / "ProjectSettings" / "ProjectVersion.txt"
+        version_file.write_text("garbage content\n")
+
+        with pytest.raises(ProjectVersionError, match="Invalid"):
+            ProjectVersion.from_file(tmp_path)
+
+    def test_frozen(self) -> None:
+        """frozen=True で不変。"""
+        sut = ProjectVersion(version="2022.3.10f1")
+        with pytest.raises(AttributeError):
+            sut.version = "2023.1.0f1"  # type: ignore[misc]
+
+
+# =============================================================================
+# is_unity_project
+# =============================================================================
+
+
+class TestIsUnityProject:
+    """is_unity_project() のテスト"""
+
+    def test_valid_project(self, tmp_path: Path) -> None:
+        """Assets/ + ProjectSettings/ + ProjectVersion.txt が全て揃う場合。"""
+        (tmp_path / "Assets").mkdir()
+        ps = tmp_path / "ProjectSettings"
+        ps.mkdir()
+        (ps / "ProjectVersion.txt").write_text("m_EditorVersion: 2022.3.10f1")
+
+        assert is_unity_project(tmp_path) is True
+
+    def test_missing_assets(self, tmp_path: Path) -> None:
+        """Assets/ がない場合。"""
+        ps = tmp_path / "ProjectSettings"
+        ps.mkdir()
+        (ps / "ProjectVersion.txt").write_text("m_EditorVersion: 2022.3.10f1")
+
+        assert is_unity_project(tmp_path) is False
+
+    def test_missing_project_settings(self, tmp_path: Path) -> None:
+        """ProjectSettings/ がない場合。"""
+        (tmp_path / "Assets").mkdir()
+        assert is_unity_project(tmp_path) is False
+
+    def test_missing_version_file(self, tmp_path: Path) -> None:
+        """ProjectVersion.txt がない場合。"""
+        (tmp_path / "Assets").mkdir()
+        (tmp_path / "ProjectSettings").mkdir()
+
+        assert is_unity_project(tmp_path) is False
+
+    def test_not_a_directory(self, tmp_path: Path) -> None:
+        """パスがファイルの場合。"""
+        file_path = tmp_path / "file.txt"
+        file_path.write_text("test")
+        assert is_unity_project(file_path) is False
+
+
+# =============================================================================
+# ProjectSettings
+# =============================================================================
+
+
+class TestProjectSettings:
+    """ProjectSettings のテスト"""
+
+    def test_from_file(self, tmp_path: Path) -> None:
+        """ProjectSettings.asset のパース。"""
+        (tmp_path / "ProjectSettings").mkdir()
+        settings_file = tmp_path / "ProjectSettings" / "ProjectSettings.asset"
+        settings_file.write_text(
+            "productName: MyGame\n"
+            "companyName: MyCorp\n"
+            "bundleVersion: 1.0.0\n"
+            "defaultScreenWidth: 1920\n"
+            "defaultScreenHeight: 1080\n"
+        )
+
+        sut = ProjectSettings.from_file(tmp_path)
+
+        assert sut.product_name == "MyGame"
+        assert sut.company_name == "MyCorp"
+        assert sut.version == "1.0.0"
+        assert sut.default_screen_width == 1920
+        assert sut.default_screen_height == 1080
+
+    def test_from_file_missing_raises(self, tmp_path: Path) -> None:
+        """ファイルが存在しない場合 ProjectError。"""
+        with pytest.raises(ProjectError, match="not found"):
+            ProjectSettings.from_file(tmp_path)
+
+    def test_from_file_defaults_for_missing_keys(self, tmp_path: Path) -> None:
+        """存在しないキーにはデフォルト値。"""
+        (tmp_path / "ProjectSettings").mkdir()
+        settings_file = tmp_path / "ProjectSettings" / "ProjectSettings.asset"
+        settings_file.write_text("someOtherKey: value\n")
+
+        sut = ProjectSettings.from_file(tmp_path)
+
+        assert sut.product_name == "Unknown"
+        assert sut.company_name == "Unknown"
+        assert sut.version == "0.1"
+        assert sut.default_screen_width == 1024
+        assert sut.default_screen_height == 768
+
+
+# =============================================================================
+# BuildSettings
+# =============================================================================
+
+
+class TestBuildSettings:
+    """BuildSettings のテスト"""
+
+    def test_from_file_with_scenes(self, tmp_path: Path) -> None:
+        """シーン情報のパース。"""
+        (tmp_path / "ProjectSettings").mkdir()
+        build_file = tmp_path / "ProjectSettings" / "EditorBuildSettings.asset"
+        build_file.write_text(
+            "m_Scenes:\n"
+            "  - enabled: 1\n"
+            "    path: Assets/Scenes/Main.unity\n"
+            "  - enabled: 0\n"
+            "    path: Assets/Scenes/Test.unity\n"
+        )
+
+        sut = BuildSettings.from_file(tmp_path)
+
+        assert len(sut.scenes) == 2
+        assert sut.scenes[0] == BuildScene(path="Assets/Scenes/Main.unity", enabled=True)
+        assert sut.scenes[1] == BuildScene(path="Assets/Scenes/Test.unity", enabled=False)
+
+    def test_from_file_missing_returns_empty(self, tmp_path: Path) -> None:
+        """ファイルが存在しない場合は空リスト。"""
+        sut = BuildSettings.from_file(tmp_path)
+        assert sut.scenes == []
+
+
+# =============================================================================
+# PackageManifest
+# =============================================================================
+
+
+class TestPackageManifest:
+    """PackageManifest のテスト"""
+
+    def test_from_file(self, tmp_path: Path) -> None:
+        """manifest.json のパース。"""
+        (tmp_path / "Packages").mkdir()
+        manifest = tmp_path / "Packages" / "manifest.json"
+        manifest.write_text(
+            json.dumps(
+                {
+                    "dependencies": {
+                        "com.unity.textmeshpro": "3.0.6",
+                        "com.example.local": "file:../local-pkg",
+                        "com.unity.modules.audio": "1.0.0",
+                    }
+                }
+            )
+        )
+
+        sut = PackageManifest.from_file(tmp_path)
+
+        # modules はスキップ
+        assert len(sut.dependencies) == 2
+        names = [d.name for d in sut.dependencies]
+        assert "com.unity.textmeshpro" in names
+        assert "com.example.local" in names
+        assert "com.unity.modules.audio" not in names
+
+    def test_local_package_detection(self, tmp_path: Path) -> None:
+        """file: プレフィックスのパッケージは is_local=True。"""
+        (tmp_path / "Packages").mkdir()
+        manifest = tmp_path / "Packages" / "manifest.json"
+        manifest.write_text(
+            json.dumps(
+                {
+                    "dependencies": {
+                        "com.example.local": "file:../pkg",
+                        "com.example.remote": "1.0.0",
+                    }
+                }
+            )
+        )
+
+        sut = PackageManifest.from_file(tmp_path)
+
+        local_pkg = next(d for d in sut.dependencies if d.name == "com.example.local")
+        remote_pkg = next(d for d in sut.dependencies if d.name == "com.example.remote")
+        assert local_pkg.is_local is True
+        assert remote_pkg.is_local is False
+
+    def test_from_file_missing_returns_empty(self, tmp_path: Path) -> None:
+        """ファイルが存在しない場合は空リスト。"""
+        sut = PackageManifest.from_file(tmp_path)
+        assert sut.dependencies == []
+
+    def test_sorted_by_name(self, tmp_path: Path) -> None:
+        """パッケージ一覧は名前順にソート。"""
+        (tmp_path / "Packages").mkdir()
+        manifest = tmp_path / "Packages" / "manifest.json"
+        manifest.write_text(
+            json.dumps(
+                {
+                    "dependencies": {
+                        "com.z.package": "1.0.0",
+                        "com.a.package": "1.0.0",
+                        "com.m.package": "1.0.0",
+                    }
+                }
+            )
+        )
+
+        sut = PackageManifest.from_file(tmp_path)
+
+        names = [d.name for d in sut.dependencies]
+        assert names == sorted(names)
+
+
+# =============================================================================
+# TagLayerSettings
+# =============================================================================
+
+
+class TestTagLayerSettings:
+    """TagLayerSettings のテスト"""
+
+    def test_from_file_missing_returns_empty(self, tmp_path: Path) -> None:
+        """ファイルが存在しない場合は空。"""
+        sut = TagLayerSettings.from_file(tmp_path)
+        assert sut.tags == []
+        assert sut.layers == []
+        assert sut.sorting_layers == []
+
+
+# =============================================================================
+# QualitySettings
+# =============================================================================
+
+
+class TestQualitySettings:
+    """QualitySettings のテスト"""
+
+    def test_from_file_missing_returns_default(self, tmp_path: Path) -> None:
+        """ファイルが存在しない場合は current_quality=0, 空リスト。"""
+        sut = QualitySettings.from_file(tmp_path)
+        assert sut.current_quality == 0
+        assert sut.levels == []
+
+
+# =============================================================================
+# AssemblyDefinition
+# =============================================================================
+
+
+class TestAssemblyDefinition:
+    """AssemblyDefinition のテスト"""
+
+    def test_from_file(self, tmp_path: Path) -> None:
+        """asmdef ファイルのパース。"""
+        asmdef = tmp_path / "Test.asmdef"
+        asmdef.write_text(
+            json.dumps(
+                {
+                    "name": "Game.Tests",
+                    "references": ["UnityEngine.TestRunner"],
+                    "includePlatforms": ["Editor"],
+                    "excludePlatforms": [],
+                    "allowUnsafeCode": True,
+                    "autoReferenced": False,
+                }
+            )
+        )
+
+        sut = AssemblyDefinition.from_file(asmdef)
+
+        assert sut.name == "Game.Tests"
+        assert sut.references == ["UnityEngine.TestRunner"]
+        assert sut.include_platforms == ["Editor"]
+        assert sut.exclude_platforms == []
+        assert sut.allow_unsafe is True
+        assert sut.auto_referenced is False
+
+    def test_from_file_defaults(self, tmp_path: Path) -> None:
+        """最小限の asmdef (name のみ)。"""
+        asmdef = tmp_path / "Minimal.asmdef"
+        asmdef.write_text(json.dumps({"name": "Minimal"}))
+
+        sut = AssemblyDefinition.from_file(asmdef)
+
+        assert sut.name == "Minimal"
+        assert sut.references == []
+        assert sut.allow_unsafe is False
+        assert sut.auto_referenced is True
+
+    def test_from_file_no_name_uses_stem(self, tmp_path: Path) -> None:
+        """name キーがない場合はファイル名を使用。"""
+        asmdef = tmp_path / "FallbackName.asmdef"
+        asmdef.write_text(json.dumps({}))
+
+        sut = AssemblyDefinition.from_file(asmdef)
+        assert sut.name == "FallbackName"
+
+
+class TestFindAssemblyDefinitions:
+    """find_assembly_definitions() のテスト"""
+
+    def test_finds_asmdef_files(self, tmp_path: Path) -> None:
+        """Assets/ 以下の .asmdef を検出。"""
+        assets = tmp_path / "Assets"
+        assets.mkdir()
+
+        (assets / "A.asmdef").write_text(json.dumps({"name": "A"}))
+        sub = assets / "Sub"
+        sub.mkdir()
+        (sub / "B.asmdef").write_text(json.dumps({"name": "B"}))
+
+        result = find_assembly_definitions(tmp_path)
+
+        names = [a.name for a in result]
+        assert "A" in names
+        assert "B" in names
+
+    def test_sorted_by_name(self, tmp_path: Path) -> None:
+        """結果は name 順にソート。"""
+        assets = tmp_path / "Assets"
+        assets.mkdir()
+
+        (assets / "Z.asmdef").write_text(json.dumps({"name": "Z"}))
+        (assets / "A.asmdef").write_text(json.dumps({"name": "A"}))
+
+        result = find_assembly_definitions(tmp_path)
+        names = [a.name for a in result]
+        assert names == sorted(names)
+
+    def test_no_assets_returns_empty(self, tmp_path: Path) -> None:
+        """Assets/ がない場合は空リスト。"""
+        result = find_assembly_definitions(tmp_path)
+        assert result == []
+
+    def test_invalid_json_skipped(self, tmp_path: Path) -> None:
+        """不正な JSON の asmdef はスキップ。"""
+        assets = tmp_path / "Assets"
+        assets.mkdir()
+
+        (assets / "Good.asmdef").write_text(json.dumps({"name": "Good"}))
+        (assets / "Bad.asmdef").write_text("not json{{{")
+
+        result = find_assembly_definitions(tmp_path)
+        assert len(result) == 1
+        assert result[0].name == "Good"
+
+
+# =============================================================================
+# ProjectInfo
+# =============================================================================
+
+
+class TestProjectInfo:
+    """ProjectInfo のテスト"""
+
+    @pytest.fixture
+    def unity_project(self, tmp_path: Path) -> Path:
+        """最小限の Unity プロジェクト構造を作成。"""
+        (tmp_path / "Assets").mkdir()
+        ps = tmp_path / "ProjectSettings"
+        ps.mkdir()
+
+        (ps / "ProjectVersion.txt").write_text("m_EditorVersion: 2022.3.10f1\n")
+        (ps / "ProjectSettings.asset").write_text(
+            "productName: TestGame\n"
+            "companyName: TestCo\n"
+            "bundleVersion: 1.0\n"
+            "defaultScreenWidth: 1920\n"
+            "defaultScreenHeight: 1080\n"
+        )
+
+        return tmp_path
+
+    def test_from_path(self, unity_project: Path) -> None:
+        """有効なプロジェクトから ProjectInfo を構築。"""
+        sut = ProjectInfo.from_path(unity_project)
+
+        assert sut.unity_version.version == "2022.3.10f1"
+        assert sut.settings.product_name == "TestGame"
+
+    def test_from_path_invalid_raises(self, tmp_path: Path) -> None:
+        """無効なプロジェクトパスで ProjectError。"""
+        with pytest.raises(ProjectError, match="Not a valid Unity project"):
+            ProjectInfo.from_path(tmp_path)
+
+    def test_to_dict(self, unity_project: Path) -> None:
+        """to_dict が正しい形式を返す。"""
+        sut = ProjectInfo.from_path(unity_project)
+        d = sut.to_dict()
+
+        assert d["unity_version"] == "2022.3.10f1"
+        assert d["product_name"] == "TestGame"
+        assert d["company_name"] == "TestCo"
+        assert "screen_size" in d
+        assert d["screen_size"]["width"] == 1920
+
+
+# =============================================================================
+# PlatformPaths / InstalledEditor dataclasses
+# =============================================================================
+
+
+class TestPlatformPaths:
+    """PlatformPaths のテスト"""
+
+    def test_frozen(self) -> None:
+        sut = PlatformPaths(hub_cli=None, editor_base=Path("/tmp"))
+        with pytest.raises(AttributeError):
+            sut.hub_cli = Path("/new")  # type: ignore[misc]
+
+
+class TestInstalledEditor:
+    """InstalledEditor のテスト"""
+
+    def test_frozen(self) -> None:
+        sut = InstalledEditor(version="2022.3.10f1", path=Path("/tmp/Unity"))
+        with pytest.raises(AttributeError):
+            sut.version = "2023.1.0f1"  # type: ignore[misc]
+
+    def test_values(self) -> None:
+        sut = InstalledEditor(version="6000.0.0f1", path=Path("/Applications/Unity"))
+        assert sut.version == "6000.0.0f1"
+        assert sut.path == Path("/Applications/Unity")
+
+
+# =============================================================================
+# HubCLI
+# =============================================================================
+
+
+class TestHubCLI:
+    """HubCLI のテスト"""
+
+    def test_init_raises_when_hub_not_found(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Hub CLI が見つからない場合 HubNotFoundError。"""
+        monkeypatch.setattr("unity_cli.hub.hub_cli.locate_hub_cli", lambda: None)
+        with pytest.raises(HubNotFoundError, match="not found"):
+            HubCLI()
+
+    def test_init_with_explicit_path(self) -> None:
+        """明示的パス指定で初期化。"""
+        sut = HubCLI(hub_path=Path("/fake/hub"))
+        assert sut._hub_path == Path("/fake/hub")
+
+    def test_list_editors_parses_output(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """editors -i 出力をパース。"""
+        sut = HubCLI(hub_path=Path("/fake/hub"))
+        mock_result = MagicMock()
+        mock_result.stdout = (
+            "2022.3.10f1 , installed at /Applications/Unity/Hub/Editor/2022.3.10f1\n"
+            "2023.1.0f1 , installed at /Applications/Unity/Hub/Editor/2023.1.0f1\n"
+        )
+        monkeypatch.setattr(sut, "_run_command", lambda args, timeout=300.0: mock_result)
+
+        editors = sut.list_editors()
+
+        assert len(editors) == 2
+        assert editors[0].version == "2022.3.10f1"
+        assert editors[1].version == "2023.1.0f1"
+
+    def test_list_editors_empty_output(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """空出力なら空リスト。"""
+        sut = HubCLI(hub_path=Path("/fake/hub"))
+        mock_result = MagicMock()
+        mock_result.stdout = ""
+        monkeypatch.setattr(sut, "_run_command", lambda args, timeout=300.0: mock_result)
+
+        assert sut.list_editors() == []
+
+    def test_install_editor_raises_on_failure(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """インストール失敗時 HubInstallError。"""
+        sut = HubCLI(hub_path=Path("/fake/hub"))
+        mock_result = MagicMock()
+        mock_result.returncode = 1
+        mock_result.stderr = "installation error"
+        monkeypatch.setattr(sut, "_run_command", lambda args, timeout=3600.0: mock_result)
+
+        with pytest.raises(HubInstallError, match="Failed to install"):
+            sut.install_editor("2022.3.10f1")
+
+    def test_install_editor_success(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """インストール成功時 True を返す。"""
+        sut = HubCLI(hub_path=Path("/fake/hub"))
+        mock_result = MagicMock()
+        mock_result.returncode = 0
+        monkeypatch.setattr(sut, "_run_command", lambda args, timeout=3600.0: mock_result)
+
+        assert sut.install_editor("2022.3.10f1") is True
+
+    def test_install_modules_raises_on_failure(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """モジュールインストール失敗時 HubInstallError。"""
+        sut = HubCLI(hub_path=Path("/fake/hub"))
+        mock_result = MagicMock()
+        mock_result.returncode = 1
+        mock_result.stderr = "module error"
+        monkeypatch.setattr(sut, "_run_command", lambda args, timeout=3600.0: mock_result)
+
+        with pytest.raises(HubInstallError, match="Failed to install modules"):
+            sut.install_modules("2022.3.10f1", ["ios"])
+
+
+class TestHubCLIRunCommand:
+    """HubCLI._run_command のテスト"""
+
+    def test_timeout_raises_hub_install_error(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """subprocess タイムアウト時 HubInstallError。"""
+        sut = HubCLI(hub_path=Path("/fake/hub"))
+        monkeypatch.setattr(
+            "subprocess.run",
+            lambda *args, **kwargs: (_ for _ in ()).throw(subprocess.TimeoutExpired(args[0], 300)),
+        )
+        with pytest.raises(HubInstallError, match="timed out"):
+            sut._run_command(["editors", "-i"])
+
+    def test_file_not_found_raises_hub_not_found(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """バイナリが見つからない場合 HubNotFoundError。"""
+        sut = HubCLI(hub_path=Path("/fake/hub"))
+        monkeypatch.setattr(
+            "subprocess.run",
+            lambda *args, **kwargs: (_ for _ in ()).throw(FileNotFoundError()),
+        )
+        with pytest.raises(HubNotFoundError, match="not found"):
+            sut._run_command(["editors", "-i"])
+
+
+# =============================================================================
+# Interactive
+# =============================================================================
+
+
+class TestIsTty:
+    """is_tty() のテスト"""
+
+    def test_returns_bool(self) -> None:
+        """戻り値は bool。"""
+        result = is_tty()
+        assert isinstance(result, bool)
+
+
+class TestPromptEditorSelection:
+    """prompt_editor_selection() のテスト"""
+
+    def test_returns_none_when_not_tty(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """TTY でない場合 None を返す。"""
+        monkeypatch.setattr("unity_cli.hub.interactive.is_tty", lambda: False)
+        editors = [InstalledEditor(version="2022.3.10f1", path=Path("/tmp"))]
+
+        result = prompt_editor_selection("2023.1.0f1", editors)
+        assert result is None
+
+
+class TestPromptConfirm:
+    """prompt_confirm() のテスト"""
+
+    def test_returns_default_when_not_tty(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """TTY でない場合 default 値を返す。"""
+        monkeypatch.setattr("unity_cli.hub.interactive.is_tty", lambda: False)
+
+        assert prompt_confirm("question?", default=True) is True
+        assert prompt_confirm("question?", default=False) is False

--- a/tests/test_menu_api.py
+++ b/tests/test_menu_api.py
@@ -10,12 +10,6 @@ from unity_cli.api.menu import MenuAPI
 
 
 @pytest.fixture
-def mock_conn() -> MagicMock:
-    """Create a mock relay connection."""
-    return MagicMock()
-
-
-@pytest.fixture
 def sut(mock_conn: MagicMock) -> MenuAPI:
     """Create a MenuAPI instance with mock connection."""
     return MenuAPI(mock_conn)

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,0 +1,252 @@
+"""Tests for unity_cli/models.py - Domain Models"""
+
+from __future__ import annotations
+
+import pytest
+from pydantic import ValidationError
+
+from unity_cli.models import Color, PaginationOptions, TestFilterOptions, Vector3
+
+
+class TestVector3:
+    """Vector3 モデルのテスト"""
+
+    def test_default_values(self) -> None:
+        """デフォルトは (0, 0, 0)。"""
+        sut = Vector3()
+        assert sut.x == 0.0
+        assert sut.y == 0.0
+        assert sut.z == 0.0
+
+    def test_custom_values(self) -> None:
+        """任意の値で生成できる。"""
+        sut = Vector3(x=1.5, y=-2.3, z=100.0)
+        assert sut.x == 1.5
+        assert sut.y == -2.3
+        assert sut.z == 100.0
+
+    def test_frozen(self) -> None:
+        """frozen=True により書き換え不可。"""
+        sut = Vector3(x=1.0)
+        with pytest.raises(ValidationError):
+            sut.x = 2.0  # type: ignore[misc]
+
+    def test_hashable(self) -> None:
+        """frozen なので hash 可能。"""
+        a = Vector3(x=1.0, y=2.0, z=3.0)
+        b = Vector3(x=1.0, y=2.0, z=3.0)
+        assert hash(a) == hash(b)
+        assert a == b
+
+    def test_to_list(self) -> None:
+        """[x, y, z] リストに変換。"""
+        sut = Vector3(x=1.0, y=2.0, z=3.0)
+        assert sut.to_list() == [1.0, 2.0, 3.0]
+
+    @pytest.mark.parametrize(
+        ("input_list", "expected"),
+        [
+            ([1.0, 2.0, 3.0], Vector3(x=1.0, y=2.0, z=3.0)),
+            ([1.0, 2.0, 3.0, 4.0], Vector3(x=1.0, y=2.0, z=3.0)),
+            ([1.0, 2.0, 3.0, 4.0, 5.0], Vector3(x=1.0, y=2.0, z=3.0)),
+        ],
+        ids=["exact-3", "extra-elements-4", "extra-elements-5"],
+    )
+    def test_from_list_valid(self, input_list: list[float], expected: Vector3) -> None:
+        """要素数 >= 3 ならば先頭3つで生成。"""
+        assert Vector3.from_list(input_list) == expected
+
+    @pytest.mark.parametrize(
+        "input_list",
+        [[], [1.0], [1.0, 2.0]],
+        ids=["empty", "one-element", "two-elements"],
+    )
+    def test_from_list_returns_default_when_insufficient(self, input_list: list[float]) -> None:
+        """要素数 < 3 はデフォルト値を返す。"""
+        assert Vector3.from_list(input_list) == Vector3()
+
+    def test_to_list_roundtrip(self) -> None:
+        """to_list -> from_list で同じ値を復元。"""
+        original = Vector3(x=3.14, y=-1.0, z=0.0)
+        assert Vector3.from_list(original.to_list()) == original
+
+
+class TestColor:
+    """Color モデルのテスト"""
+
+    def test_default_values(self) -> None:
+        """デフォルトは白 (1, 1, 1, 1)。"""
+        sut = Color()
+        assert sut.r == 1.0
+        assert sut.g == 1.0
+        assert sut.b == 1.0
+        assert sut.a == 1.0
+
+    def test_custom_values(self) -> None:
+        """任意の RGBA 値で生成。"""
+        sut = Color(r=0.5, g=0.3, b=0.1, a=0.8)
+        assert sut.r == 0.5
+        assert sut.a == 0.8
+
+    def test_frozen(self) -> None:
+        """frozen=True により書き換え不可。"""
+        sut = Color()
+        with pytest.raises(ValidationError):
+            sut.r = 0.5  # type: ignore[misc]
+
+    @pytest.mark.parametrize(
+        ("field", "value"),
+        [
+            ("r", -0.1),
+            ("g", 1.1),
+            ("b", -1.0),
+            ("a", 2.0),
+        ],
+    )
+    def test_out_of_range_raises(self, field: str, value: float) -> None:
+        """0.0-1.0 範囲外は ValidationError。"""
+        with pytest.raises(ValidationError):
+            Color(**{field: value})
+
+    @pytest.mark.parametrize(
+        ("value",),
+        [(0.0,), (0.5,), (1.0,)],
+    )
+    def test_boundary_values_accepted(self, value: float) -> None:
+        """境界値 0.0, 0.5, 1.0 は有効。"""
+        sut = Color(r=value, g=value, b=value, a=value)
+        assert sut.r == value
+
+    def test_to_list(self) -> None:
+        """[r, g, b, a] リストに変換。"""
+        sut = Color(r=0.1, g=0.2, b=0.3, a=0.4)
+        assert sut.to_list() == [0.1, 0.2, 0.3, 0.4]
+
+    @pytest.mark.parametrize(
+        ("input_list", "expected"),
+        [
+            ([0.1, 0.2, 0.3, 0.4], Color(r=0.1, g=0.2, b=0.3, a=0.4)),
+            ([0.1, 0.2, 0.3, 0.4, 0.5], Color(r=0.1, g=0.2, b=0.3, a=0.4)),
+            ([0.1, 0.2, 0.3], Color(r=0.1, g=0.2, b=0.3, a=1.0)),
+        ],
+        ids=["rgba-4", "extra-elements", "rgb-3-default-alpha"],
+    )
+    def test_from_list_valid(self, input_list: list[float], expected: Color) -> None:
+        """要素数 >= 3 ならば適切に生成。"""
+        assert Color.from_list(input_list) == expected
+
+    @pytest.mark.parametrize(
+        "input_list",
+        [[], [0.1], [0.1, 0.2]],
+        ids=["empty", "one-element", "two-elements"],
+    )
+    def test_from_list_returns_default_when_insufficient(self, input_list: list[float]) -> None:
+        """要素数 < 3 はデフォルト値を返す。"""
+        assert Color.from_list(input_list) == Color()
+
+    def test_to_list_roundtrip(self) -> None:
+        """to_list -> from_list で同じ値を復元。"""
+        original = Color(r=0.2, g=0.4, b=0.6, a=0.8)
+        assert Color.from_list(original.to_list()) == original
+
+
+class TestPaginationOptions:
+    """PaginationOptions モデルのテスト"""
+
+    def test_defaults(self) -> None:
+        """デフォルト値: page_size=50, cursor=None, max_nodes=None。"""
+        sut = PaginationOptions()
+        assert sut.page_size == 50
+        assert sut.cursor is None
+        assert sut.max_nodes is None
+
+    def test_custom_values(self) -> None:
+        """任意の値で生成。"""
+        sut = PaginationOptions(page_size=100, cursor=5, max_nodes=200)
+        assert sut.page_size == 100
+        assert sut.cursor == 5
+        assert sut.max_nodes == 200
+
+    def test_cursor_as_string(self) -> None:
+        """cursor は str でも指定可能。"""
+        sut = PaginationOptions(cursor="abc123")
+        assert sut.cursor == "abc123"
+
+    @pytest.mark.parametrize(
+        "page_size",
+        [0, -1],
+        ids=["zero", "negative"],
+    )
+    def test_page_size_must_be_positive(self, page_size: int) -> None:
+        """page_size <= 0 は ValidationError。"""
+        with pytest.raises(ValidationError):
+            PaginationOptions(page_size=page_size)
+
+    def test_page_size_max_1000(self) -> None:
+        """page_size > 1000 は ValidationError。"""
+        with pytest.raises(ValidationError):
+            PaginationOptions(page_size=1001)
+
+    def test_page_size_boundary_1000(self) -> None:
+        """page_size = 1000 は有効。"""
+        sut = PaginationOptions(page_size=1000)
+        assert sut.page_size == 1000
+
+    def test_page_size_boundary_1(self) -> None:
+        """page_size = 1 は有効。"""
+        sut = PaginationOptions(page_size=1)
+        assert sut.page_size == 1
+
+    def test_max_nodes_must_be_positive(self) -> None:
+        """max_nodes <= 0 は ValidationError。"""
+        with pytest.raises(ValidationError):
+            PaginationOptions(max_nodes=0)
+
+    def test_frozen(self) -> None:
+        """frozen=True により書き換え不可。"""
+        sut = PaginationOptions()
+        with pytest.raises(ValidationError):
+            sut.page_size = 10  # type: ignore[misc]
+
+
+class TestTestFilterOptions:
+    """TestFilterOptions モデルのテスト"""
+
+    def test_defaults_all_none(self) -> None:
+        """デフォルトは全フィルタ None。"""
+        sut = TestFilterOptions()
+        assert sut.test_names is None
+        assert sut.group_names is None
+        assert sut.category_names is None
+        assert sut.assembly_names is None
+
+    def test_with_test_names(self) -> None:
+        """test_names を指定。"""
+        sut = TestFilterOptions(test_names=["Ns.Tests.TestA", "Ns.Tests.TestB"])
+        assert sut.test_names is not None
+        assert len(sut.test_names) == 2
+
+    def test_with_all_filters(self) -> None:
+        """全フィルタを同時に指定。"""
+        sut = TestFilterOptions(
+            test_names=["Test1"],
+            group_names=[".*Integration.*"],
+            category_names=["Smoke"],
+            assembly_names=["Game.Tests"],
+        )
+        assert sut.test_names is not None
+        assert sut.group_names is not None
+        assert sut.category_names is not None
+        assert sut.assembly_names is not None
+
+    def test_empty_sequences(self) -> None:
+        """空シーケンスも有効。"""
+        sut = TestFilterOptions(test_names=[], group_names=[])
+        assert sut.test_names is not None
+        assert len(sut.test_names) == 0
+
+    def test_frozen(self) -> None:
+        """frozen=True により書き換え不可。"""
+        sut = TestFilterOptions()
+        with pytest.raises(ValidationError):
+            sut.test_names = ["x"]  # type: ignore[misc]

--- a/tests/test_package_api.py
+++ b/tests/test_package_api.py
@@ -10,11 +10,6 @@ from unity_cli.api.package import PackageAPI
 
 
 @pytest.fixture
-def mock_conn() -> MagicMock:
-    return MagicMock()
-
-
-@pytest.fixture
 def sut(mock_conn: MagicMock) -> PackageAPI:
     return PackageAPI(mock_conn)
 

--- a/tests/test_profiler_api.py
+++ b/tests/test_profiler_api.py
@@ -10,11 +10,6 @@ from unity_cli.api.profiler import ProfilerAPI
 
 
 @pytest.fixture
-def mock_conn() -> MagicMock:
-    return MagicMock()
-
-
-@pytest.fixture
 def sut(mock_conn: MagicMock) -> ProfilerAPI:
     return ProfilerAPI(mock_conn)
 

--- a/tests/test_recorder_api.py
+++ b/tests/test_recorder_api.py
@@ -1,0 +1,173 @@
+"""Tests for unity_cli/api/recorder.py - Recorder API"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from unity_cli.api.recorder import RecorderAPI
+
+
+@pytest.fixture
+def mock_conn() -> MagicMock:
+    """Create a mock relay connection."""
+    return MagicMock()
+
+
+@pytest.fixture
+def sut(mock_conn: MagicMock) -> RecorderAPI:
+    """Create a RecorderAPI instance with mock connection."""
+    return RecorderAPI(mock_conn)
+
+
+class TestStart:
+    """start() メソッドのテスト"""
+
+    def test_sends_recorder_command(self, sut: RecorderAPI, mock_conn: MagicMock) -> None:
+        """Send 'recorder' as the command name."""
+        mock_conn.send_request.return_value = {}
+
+        sut.start()
+
+        assert mock_conn.send_request.call_args[0][0] == "recorder"
+
+    def test_sends_start_action(self, sut: RecorderAPI, mock_conn: MagicMock) -> None:
+        """Send action='start' をパラメータに含む。"""
+        mock_conn.send_request.return_value = {}
+
+        sut.start()
+
+        params = mock_conn.send_request.call_args[0][1]
+        assert params["action"] == "start"
+
+    def test_default_params(self, sut: RecorderAPI, mock_conn: MagicMock) -> None:
+        """デフォルトパラメータの確認。"""
+        mock_conn.send_request.return_value = {}
+
+        sut.start()
+
+        params = mock_conn.send_request.call_args[0][1]
+        assert params["fps"] == 30
+        assert params["format"] == "jpg"
+        assert params["quality"] == 75
+        assert params["width"] == 1920
+        assert params["height"] == 1080
+
+    def test_custom_params(self, sut: RecorderAPI, mock_conn: MagicMock) -> None:
+        """カスタムパラメータが正しく送信される。"""
+        mock_conn.send_request.return_value = {}
+
+        sut.start(fps=60, format="png", quality=100, width=3840, height=2160)
+
+        params = mock_conn.send_request.call_args[0][1]
+        assert params["fps"] == 60
+        assert params["format"] == "png"
+        assert params["quality"] == 100
+        assert params["width"] == 3840
+        assert params["height"] == 2160
+
+    def test_camera_param_included_when_set(self, sut: RecorderAPI, mock_conn: MagicMock) -> None:
+        """camera 指定時にパラメータに含まれる。"""
+        mock_conn.send_request.return_value = {}
+
+        sut.start(camera="OverviewCam")
+
+        params = mock_conn.send_request.call_args[0][1]
+        assert params["camera"] == "OverviewCam"
+
+    def test_camera_param_excluded_when_none(self, sut: RecorderAPI, mock_conn: MagicMock) -> None:
+        """camera=None の場合パラメータに含まれない。"""
+        mock_conn.send_request.return_value = {}
+
+        sut.start()
+
+        params = mock_conn.send_request.call_args[0][1]
+        assert "camera" not in params
+
+    def test_output_dir_included_when_set(self, sut: RecorderAPI, mock_conn: MagicMock) -> None:
+        """output_dir 指定時にパラメータに含まれる。"""
+        mock_conn.send_request.return_value = {}
+
+        sut.start(output_dir="/tmp/frames")
+
+        params = mock_conn.send_request.call_args[0][1]
+        assert params["outputDir"] == "/tmp/frames"
+
+    def test_output_dir_excluded_when_none(self, sut: RecorderAPI, mock_conn: MagicMock) -> None:
+        """output_dir=None の場合パラメータに含まれない。"""
+        mock_conn.send_request.return_value = {}
+
+        sut.start()
+
+        params = mock_conn.send_request.call_args[0][1]
+        assert "outputDir" not in params
+
+    def test_returns_response(self, sut: RecorderAPI, mock_conn: MagicMock) -> None:
+        """send_request の戻り値をそのまま返す。"""
+        expected = {"message": "Recording started", "outputDir": "/tmp/frames"}
+        mock_conn.send_request.return_value = expected
+
+        result = sut.start()
+
+        assert result == expected
+
+
+class TestStop:
+    """stop() メソッドのテスト"""
+
+    def test_sends_recorder_command(self, sut: RecorderAPI, mock_conn: MagicMock) -> None:
+        """Send 'recorder' as the command name."""
+        mock_conn.send_request.return_value = {}
+
+        sut.stop()
+
+        assert mock_conn.send_request.call_args[0][0] == "recorder"
+
+    def test_sends_stop_action(self, sut: RecorderAPI, mock_conn: MagicMock) -> None:
+        """Send action='stop'。"""
+        mock_conn.send_request.return_value = {}
+
+        sut.stop()
+
+        params = mock_conn.send_request.call_args[0][1]
+        assert params == {"action": "stop"}
+
+    def test_returns_response(self, sut: RecorderAPI, mock_conn: MagicMock) -> None:
+        """結果（frameCount, elapsed 等）を返す。"""
+        expected = {"frameCount": 300, "elapsed": 10.0, "fps": 30.0, "outputDir": "/tmp/frames"}
+        mock_conn.send_request.return_value = expected
+
+        result = sut.stop()
+
+        assert result == expected
+
+
+class TestStatus:
+    """status() メソッドのテスト"""
+
+    def test_sends_recorder_command(self, sut: RecorderAPI, mock_conn: MagicMock) -> None:
+        """Send 'recorder' as the command name."""
+        mock_conn.send_request.return_value = {}
+
+        sut.status()
+
+        assert mock_conn.send_request.call_args[0][0] == "recorder"
+
+    def test_sends_status_action(self, sut: RecorderAPI, mock_conn: MagicMock) -> None:
+        """Send action='status'。"""
+        mock_conn.send_request.return_value = {}
+
+        sut.status()
+
+        params = mock_conn.send_request.call_args[0][1]
+        assert params == {"action": "status"}
+
+    def test_returns_response(self, sut: RecorderAPI, mock_conn: MagicMock) -> None:
+        """録画状態を返す。"""
+        expected = {"recording": True, "frameCount": 150, "elapsed": 5.0, "fps": 30.0, "pendingWrites": 2}
+        mock_conn.send_request.return_value = expected
+
+        result = sut.status()
+
+        assert result == expected

--- a/tests/test_relay_characterization.py
+++ b/tests/test_relay_characterization.py
@@ -1,0 +1,460 @@
+"""Characterization tests for relay/ package.
+
+Freeze current behavior and constants to detect unintended changes
+during refactoring.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from relay.instance_registry import QUEUE_ENABLED, QUEUE_MAX_SIZE, UnityInstance
+from relay.protocol import (
+    HEADER_SIZE,
+    MAX_PAYLOAD_BYTES,
+    PROTOCOL_VERSION,
+    CommandMessage,
+    CommandResultMessage,
+    ErrorCode,
+    ErrorMessage,
+    InstancesMessage,
+    InstanceStatus,
+    MessageType,
+    PingMessage,
+    PongMessage,
+    RegisteredMessage,
+    RegisterMessage,
+    RequestMessage,
+    ResponseMessage,
+    StatusMessage,
+)
+from relay.server import (
+    _VALID_DETAILS,
+    COMMAND_TIMEOUT_MS,
+    DEFAULT_HOST,
+    DEFAULT_PORT,
+    HEARTBEAT_INTERVAL_MS,
+    HEARTBEAT_MAX_RETRIES,
+    HEARTBEAT_TIMEOUT_MS,
+    LOG_BACKUP_COUNT,
+    LOG_FORMAT,
+    LOG_MAX_BYTES,
+    RELOAD_GRACE_PERIOD_MS,
+    RELOAD_TIMEOUT_MS,
+)
+
+# =============================================================================
+# Protocol Constants
+# =============================================================================
+
+
+class TestProtocolConstantsCharacterization:
+    """Freeze protocol constants to prevent accidental changes."""
+
+    def test_protocol_version(self) -> None:
+        assert PROTOCOL_VERSION == "1.0"
+
+    def test_header_size(self) -> None:
+        assert HEADER_SIZE == 4
+
+    def test_max_payload_bytes(self) -> None:
+        assert MAX_PAYLOAD_BYTES == 16 * 1024 * 1024  # 16 MiB
+
+
+# =============================================================================
+# Message Types
+# =============================================================================
+
+
+class TestMessageTypesCharacterization:
+    """Freeze all MessageType enum values."""
+
+    EXPECTED_MESSAGE_TYPES = {
+        # Unity -> Relay
+        "REGISTER": "REGISTER",
+        "REGISTERED": "REGISTERED",
+        "STATUS": "STATUS",
+        "COMMAND_RESULT": "COMMAND_RESULT",
+        "PONG": "PONG",
+        # Relay -> Unity
+        "PING": "PING",
+        "COMMAND": "COMMAND",
+        # CLI -> Relay
+        "REQUEST": "REQUEST",
+        "LIST_INSTANCES": "LIST_INSTANCES",
+        "SET_DEFAULT": "SET_DEFAULT",
+        # Relay -> CLI
+        "RESPONSE": "RESPONSE",
+        "ERROR": "ERROR",
+        "INSTANCES": "INSTANCES",
+    }
+
+    def test_all_message_types_present(self) -> None:
+        """All expected message types exist."""
+        actual = {mt.name: mt.value for mt in MessageType}
+        assert actual == self.EXPECTED_MESSAGE_TYPES
+
+    def test_message_type_count(self) -> None:
+        """Total number of message types is frozen."""
+        assert len(MessageType) == 13
+
+
+# =============================================================================
+# Error Codes
+# =============================================================================
+
+
+class TestErrorCodesCharacterization:
+    """Freeze all ErrorCode enum values."""
+
+    EXPECTED_ERROR_CODES = {
+        "INSTANCE_NOT_FOUND": "INSTANCE_NOT_FOUND",
+        "INSTANCE_RELOADING": "INSTANCE_RELOADING",
+        "INSTANCE_BUSY": "INSTANCE_BUSY",
+        "INSTANCE_DISCONNECTED": "INSTANCE_DISCONNECTED",
+        "COMMAND_NOT_FOUND": "COMMAND_NOT_FOUND",
+        "INVALID_PARAMS": "INVALID_PARAMS",
+        "TIMEOUT": "TIMEOUT",
+        "INTERNAL_ERROR": "INTERNAL_ERROR",
+        "PROTOCOL_ERROR": "PROTOCOL_ERROR",
+        "MALFORMED_JSON": "MALFORMED_JSON",
+        "PAYLOAD_TOO_LARGE": "PAYLOAD_TOO_LARGE",
+        "PROTOCOL_VERSION_MISMATCH": "PROTOCOL_VERSION_MISMATCH",
+        "CAPABILITY_NOT_SUPPORTED": "CAPABILITY_NOT_SUPPORTED",
+        "QUEUE_FULL": "QUEUE_FULL",
+        "STALE_REF": "STALE_REF",
+        "AMBIGUOUS_INSTANCE": "AMBIGUOUS_INSTANCE",
+    }
+
+    def test_all_error_codes_present(self) -> None:
+        """All expected error codes exist."""
+        actual = {ec.name: ec.value for ec in ErrorCode}
+        assert actual == self.EXPECTED_ERROR_CODES
+
+    def test_error_code_count(self) -> None:
+        """Total number of error codes is frozen."""
+        assert len(ErrorCode) == 16
+
+
+# =============================================================================
+# Instance Status
+# =============================================================================
+
+
+class TestInstanceStatusCharacterization:
+    """Freeze all InstanceStatus enum values."""
+
+    EXPECTED_STATUSES = {
+        "READY": "ready",
+        "BUSY": "busy",
+        "RELOADING": "reloading",
+        "DISCONNECTED": "disconnected",
+    }
+
+    def test_all_statuses_present(self) -> None:
+        """All expected status values exist."""
+        actual = {s.name: s.value for s in InstanceStatus}
+        assert actual == self.EXPECTED_STATUSES
+
+    def test_status_count(self) -> None:
+        """Total number of statuses is frozen."""
+        assert len(InstanceStatus) == 4
+
+    @pytest.mark.parametrize(
+        ("status", "value"),
+        [
+            (InstanceStatus.READY, "ready"),
+            (InstanceStatus.BUSY, "busy"),
+            (InstanceStatus.RELOADING, "reloading"),
+            (InstanceStatus.DISCONNECTED, "disconnected"),
+        ],
+    )
+    def test_status_string_values(self, status: InstanceStatus, value: str) -> None:
+        """Status string values match expected lowercase format."""
+        assert status.value == value
+
+
+# =============================================================================
+# Heartbeat Constants
+# =============================================================================
+
+
+class TestHeartbeatConstantsCharacterization:
+    """Freeze heartbeat timing constants."""
+
+    def test_heartbeat_interval(self) -> None:
+        assert HEARTBEAT_INTERVAL_MS == 5000
+
+    def test_heartbeat_timeout(self) -> None:
+        assert HEARTBEAT_TIMEOUT_MS == 15000
+
+    def test_heartbeat_max_retries(self) -> None:
+        assert HEARTBEAT_MAX_RETRIES == 3
+
+    def test_reload_timeout(self) -> None:
+        assert RELOAD_TIMEOUT_MS == 30000
+
+    def test_reload_timeout_exceeds_heartbeat_timeout(self) -> None:
+        """RELOAD_TIMEOUT must be >= HEARTBEAT_TIMEOUT for extended tolerance."""
+        assert RELOAD_TIMEOUT_MS >= HEARTBEAT_TIMEOUT_MS
+
+
+# =============================================================================
+# Server Configuration Constants
+# =============================================================================
+
+
+class TestServerConfigCharacterization:
+    """Freeze server configuration constants."""
+
+    def test_default_host(self) -> None:
+        assert DEFAULT_HOST == "127.0.0.1"
+
+    def test_default_port(self) -> None:
+        assert DEFAULT_PORT == 6500
+
+    def test_command_timeout(self) -> None:
+        assert COMMAND_TIMEOUT_MS == 30000
+
+    def test_reload_grace_period(self) -> None:
+        assert RELOAD_GRACE_PERIOD_MS == 60000
+
+
+# =============================================================================
+# Queue Constants
+# =============================================================================
+
+
+class TestQueueConstantsCharacterization:
+    """Freeze command queue configuration."""
+
+    def test_queue_max_size(self) -> None:
+        assert QUEUE_MAX_SIZE == 10
+
+    def test_queue_disabled_by_default(self) -> None:
+        assert QUEUE_ENABLED is False
+
+
+# =============================================================================
+# Logging Constants
+# =============================================================================
+
+
+class TestLoggingConstantsCharacterization:
+    """Freeze logging configuration."""
+
+    def test_log_format(self) -> None:
+        assert LOG_FORMAT == "%(asctime)s [%(levelname)s] %(name)s: %(message)s"
+
+    def test_log_max_bytes(self) -> None:
+        assert LOG_MAX_BYTES == 10 * 1024 * 1024  # 10 MB
+
+    def test_log_backup_count(self) -> None:
+        assert LOG_BACKUP_COUNT == 5
+
+
+# =============================================================================
+# Valid Status Details
+# =============================================================================
+
+
+class TestValidDetailsCharacterization:
+    """Freeze allowed status detail values."""
+
+    EXPECTED_DETAILS = frozenset(
+        {
+            "compiling",
+            "running_tests",
+            "asset_import",
+            "playmode_transition",
+            "editor_blocked",
+        }
+    )
+
+    def test_all_valid_details(self) -> None:
+        assert _VALID_DETAILS == self.EXPECTED_DETAILS
+
+    def test_valid_details_count(self) -> None:
+        assert len(_VALID_DETAILS) == 5
+
+
+# =============================================================================
+# Message Serialization Shape
+# =============================================================================
+
+
+class TestMessageSerializationCharacterization:
+    """Freeze message serialization structure."""
+
+    def test_register_message_keys(self) -> None:
+        """RegisterMessage produces expected keys."""
+        msg = RegisterMessage(
+            instance_id="/test",
+            project_name="Test",
+            unity_version="2022.3",
+            capabilities=["manage_editor"],
+        )
+        d = msg.to_dict()
+        expected_keys = {
+            "type",
+            "ts",
+            "protocol_version",
+            "instance_id",
+            "project_name",
+            "unity_version",
+            "capabilities",
+            "bridge_version",
+        }
+        assert set(d.keys()) == expected_keys
+
+    def test_registered_message_success_keys(self) -> None:
+        """RegisteredMessage (success) produces expected keys."""
+        msg = RegisteredMessage(success=True, heartbeat_interval_ms=5000)
+        d = msg.to_dict()
+        expected_keys = {"type", "ts", "success", "heartbeat_interval_ms"}
+        assert set(d.keys()) == expected_keys
+
+    def test_registered_message_error_keys(self) -> None:
+        """RegisteredMessage (error) produces expected keys."""
+        msg = RegisteredMessage(success=False, error={"code": "ERR", "message": "msg"})
+        d = msg.to_dict()
+        assert "error" in d
+        assert "success" in d
+
+    def test_ping_message_keys(self) -> None:
+        """PingMessage produces expected keys."""
+        msg = PingMessage()
+        d = msg.to_dict()
+        expected_keys = {"type", "ts"}
+        assert set(d.keys()) == expected_keys
+
+    def test_command_message_keys(self) -> None:
+        """CommandMessage produces expected keys."""
+        msg = CommandMessage(id="req-1", command="test", params={"key": "val"}, timeout_ms=30000)
+        d = msg.to_dict()
+        expected_keys = {"type", "ts", "id", "command", "params", "timeout_ms"}
+        assert set(d.keys()) == expected_keys
+
+    def test_response_message_keys(self) -> None:
+        """ResponseMessage produces expected keys."""
+        msg = ResponseMessage(id="req-1", success=True, data={"result": "ok"})
+        d = msg.to_dict()
+        # relay_version and bridge_version are empty strings, still serialized
+        assert "type" in d
+        assert "id" in d
+        assert "success" in d
+        assert "data" in d
+
+    def test_error_message_from_code_structure(self) -> None:
+        """ErrorMessage.from_code produces correct structure."""
+        msg = ErrorMessage.from_code("req-1", ErrorCode.TIMEOUT, "Timed out")
+        d = msg.to_dict()
+        assert d["type"] == "ERROR"
+        assert d["success"] is False
+        assert d["error"]["code"] == "TIMEOUT"
+        assert d["error"]["message"] == "Timed out"
+        assert d["id"] == "req-1"
+
+    def test_instances_message_keys(self) -> None:
+        """InstancesMessage produces expected keys."""
+        msg = InstancesMessage(id="req-list", success=True, data={"instances": []})
+        d = msg.to_dict()
+        expected_keys = {"type", "ts", "id", "success", "data"}
+        assert set(d.keys()) == expected_keys
+
+
+# =============================================================================
+# UnityInstance.to_dict Shape
+# =============================================================================
+
+
+class TestInstanceDictCharacterization:
+    """Freeze UnityInstance.to_dict() output shape."""
+
+    def test_to_dict_keys_without_detail(self) -> None:
+        """to_dict without status_detail produces expected keys."""
+        instance = UnityInstance(
+            instance_id="/test",
+            project_name="Test",
+            unity_version="2022.3",
+            ref_id=1,
+            capabilities=["manage_editor"],
+            status=InstanceStatus.READY,
+        )
+        d = instance.to_dict(is_default=True)
+        expected_keys = {
+            "ref_id",
+            "instance_id",
+            "project_name",
+            "unity_version",
+            "bridge_version",
+            "status",
+            "is_default",
+            "capabilities",
+            "queue_size",
+        }
+        assert set(d.keys()) == expected_keys
+
+    def test_to_dict_keys_with_detail(self) -> None:
+        """to_dict with status_detail adds the key."""
+        instance = UnityInstance(
+            instance_id="/test",
+            project_name="Test",
+            unity_version="2022.3",
+            ref_id=1,
+            status=InstanceStatus.BUSY,
+            status_detail="compiling",
+        )
+        d = instance.to_dict()
+        assert "status_detail" in d
+        assert d["status_detail"] == "compiling"
+
+
+# =============================================================================
+# ErrorMessage Default Values
+# =============================================================================
+
+
+class TestErrorMessageDefaults:
+    """Freeze ErrorMessage default field values."""
+
+    def test_default_success_is_false(self) -> None:
+        msg = ErrorMessage()
+        assert msg.success is False
+
+    def test_default_type_is_error(self) -> None:
+        msg = ErrorMessage()
+        assert msg.type == "ERROR"
+
+
+# =============================================================================
+# Message Type Literal Values
+# =============================================================================
+
+
+class TestMessageTypeLiterals:
+    """Verify each message class produces correct 'type' value."""
+
+    @pytest.mark.parametrize(
+        ("cls", "expected_type"),
+        [
+            (RegisterMessage, "REGISTER"),
+            (RegisteredMessage, "REGISTERED"),
+            (StatusMessage, "STATUS"),
+            (CommandResultMessage, "COMMAND_RESULT"),
+            (PongMessage, "PONG"),
+            (PingMessage, "PING"),
+            (CommandMessage, "COMMAND"),
+            (ResponseMessage, "RESPONSE"),
+            (ErrorMessage, "ERROR"),
+            (InstancesMessage, "INSTANCES"),
+        ],
+    )
+    def test_message_class_type_value(self, cls: type, expected_type: str) -> None:
+        """Each message class serializes to the correct 'type' string."""
+        # CommandMessage and RequestMessage require command to be non-empty
+        if cls is CommandMessage or cls is RequestMessage:
+            msg = cls(command="test")
+        else:
+            msg = cls()
+        assert msg.to_dict()["type"] == expected_type

--- a/tests/test_relay_state_machine.py
+++ b/tests/test_relay_state_machine.py
@@ -1,0 +1,694 @@
+"""Tests for relay/server.py - State machine, heartbeat, and command queueing logic."""
+
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from relay.instance_registry import QueuedCommand, UnityInstance
+from relay.protocol import (
+    ErrorCode,
+    InstanceStatus,
+    MessageType,
+)
+from relay.server import (
+    COMMAND_TIMEOUT_MS,
+    HEARTBEAT_MAX_RETRIES,
+    HEARTBEAT_TIMEOUT_MS,
+    RELOAD_TIMEOUT_MS,
+    RelayServer,
+)
+
+# =============================================================================
+# Helpers
+# =============================================================================
+
+
+def _make_writer(*, closing: bool = False) -> MagicMock:
+    """Create a mock asyncio.StreamWriter."""
+    writer = MagicMock()
+    writer.is_closing.return_value = closing
+    writer.close = MagicMock()
+    writer.wait_closed = AsyncMock()
+    writer.write = MagicMock()
+    writer.drain = AsyncMock()
+    return writer
+
+
+def _make_instance(
+    instance_id: str = "/test/Project",
+    status: InstanceStatus = InstanceStatus.READY,
+    *,
+    queue_enabled: bool = False,
+) -> UnityInstance:
+    """Create a UnityInstance with a mock writer."""
+    writer = _make_writer()
+    return UnityInstance(
+        instance_id=instance_id,
+        project_name="Project",
+        unity_version="2022.3",
+        status=status,
+        writer=writer,
+        reader=MagicMock(),
+        queue_enabled=queue_enabled,
+    )
+
+
+# =============================================================================
+# State Transitions
+# =============================================================================
+
+
+class TestStateTransitions:
+    """Test Unity instance state transitions via _handle_unity_message."""
+
+    @pytest.fixture
+    def server(self) -> RelayServer:
+        return RelayServer()
+
+    def test_ready_to_busy_via_set_status(self) -> None:
+        """READY -> BUSY transition when command is sent."""
+        instance = _make_instance(status=InstanceStatus.READY)
+        instance.set_status(InstanceStatus.BUSY)
+        assert instance.status == InstanceStatus.BUSY
+
+    def test_busy_to_ready_via_set_status(self) -> None:
+        """BUSY -> READY transition when command completes."""
+        instance = _make_instance(status=InstanceStatus.BUSY)
+        instance.set_status(InstanceStatus.READY)
+        assert instance.status == InstanceStatus.READY
+
+    def test_ready_to_reloading_via_set_status(self) -> None:
+        """READY -> RELOADING transition on domain reload."""
+        instance = _make_instance(status=InstanceStatus.READY)
+        instance.set_status(InstanceStatus.RELOADING)
+        assert instance.status == InstanceStatus.RELOADING
+        assert instance.reloading_since is not None
+
+    def test_reloading_to_ready_clears_reloading_since(self) -> None:
+        """RELOADING -> READY clears reloading_since."""
+        instance = _make_instance(status=InstanceStatus.RELOADING)
+        instance.reloading_since = 12345.0
+        instance.set_status(InstanceStatus.READY)
+        assert instance.status == InstanceStatus.READY
+        assert instance.reloading_since is None
+
+    async def test_status_message_updates_instance_status(self, server: RelayServer) -> None:
+        """STATUS message from Unity updates instance status in registry."""
+        instance = _make_instance()
+        server.registry._instances[instance.instance_id] = instance
+
+        msg = {"type": MessageType.STATUS.value, "status": "reloading"}
+        await server._handle_unity_message(instance, msg)
+
+        assert instance.status == InstanceStatus.RELOADING
+
+    async def test_status_message_busy_to_ready_triggers_queue_processing(self, server: RelayServer) -> None:
+        """BUSY -> READY transition via STATUS message triggers queue processing."""
+        instance = _make_instance(status=InstanceStatus.BUSY, queue_enabled=True)
+        server.registry._instances[instance.instance_id] = instance
+
+        # Patch _process_queue to verify it gets called
+        with patch.object(server, "_process_queue", new_callable=AsyncMock) as mock_process:
+            msg = {"type": MessageType.STATUS.value, "status": "ready"}
+            await server._handle_unity_message(instance, msg)
+
+            assert instance.status == InstanceStatus.READY
+            mock_process.assert_awaited_once_with(instance)
+
+    async def test_status_message_ready_to_ready_no_queue_trigger(self, server: RelayServer) -> None:
+        """READY -> READY transition does not trigger queue processing."""
+        instance = _make_instance(status=InstanceStatus.READY, queue_enabled=True)
+        server.registry._instances[instance.instance_id] = instance
+
+        with patch.object(server, "_process_queue", new_callable=AsyncMock) as mock_process:
+            msg = {"type": MessageType.STATUS.value, "status": "ready"}
+            await server._handle_unity_message(instance, msg)
+            mock_process.assert_not_awaited()
+
+    async def test_status_message_with_detail(self, server: RelayServer) -> None:
+        """STATUS message with valid detail stores it."""
+        instance = _make_instance(status=InstanceStatus.READY)
+        server.registry._instances[instance.instance_id] = instance
+
+        msg = {"type": MessageType.STATUS.value, "status": "busy", "detail": "compiling"}
+        await server._handle_unity_message(instance, msg)
+
+        assert instance.status == InstanceStatus.BUSY
+        assert instance.status_detail == "compiling"
+
+    async def test_status_message_with_invalid_detail_ignored(self, server: RelayServer) -> None:
+        """STATUS message with invalid detail drops it."""
+        instance = _make_instance(status=InstanceStatus.READY)
+        server.registry._instances[instance.instance_id] = instance
+
+        msg = {"type": MessageType.STATUS.value, "status": "busy", "detail": "invalid_detail"}
+        await server._handle_unity_message(instance, msg)
+
+        assert instance.status == InstanceStatus.BUSY
+        assert instance.status_detail is None
+
+    async def test_unknown_status_value_ignored(self, server: RelayServer) -> None:
+        """Unknown status value does not change instance status."""
+        instance = _make_instance(status=InstanceStatus.READY)
+        server.registry._instances[instance.instance_id] = instance
+
+        msg = {"type": MessageType.STATUS.value, "status": "unknown_state"}
+        await server._handle_unity_message(instance, msg)
+
+        assert instance.status == InstanceStatus.READY
+
+
+# =============================================================================
+# COMMAND_RESULT Handling
+# =============================================================================
+
+
+class TestCommandResult:
+    """Test COMMAND_RESULT message handling."""
+
+    @pytest.fixture
+    def server(self) -> RelayServer:
+        return RelayServer()
+
+    async def test_command_result_resolves_pending_future(self, server: RelayServer) -> None:
+        """COMMAND_RESULT resolves the pending command future."""
+        instance = _make_instance()
+        future: asyncio.Future[dict] = asyncio.get_event_loop().create_future()
+        server._pending_commands["req-1"] = future
+
+        msg = {
+            "type": MessageType.COMMAND_RESULT.value,
+            "id": "req-1",
+            "success": True,
+            "data": {"isPlaying": True},
+        }
+        await server._handle_unity_message(instance, msg)
+
+        assert future.done()
+        assert future.result()["success"] is True
+        assert "req-1" not in server._pending_commands
+
+    async def test_late_command_result_ignored(self, server: RelayServer) -> None:
+        """Late COMMAND_RESULT (already timed out) is silently ignored."""
+        instance = _make_instance()
+        # No pending command registered for "req-2"
+
+        msg = {
+            "type": MessageType.COMMAND_RESULT.value,
+            "id": "req-2",
+            "success": True,
+            "data": {},
+        }
+        # Should not raise
+        await server._handle_unity_message(instance, msg)
+
+
+# =============================================================================
+# PONG Handling
+# =============================================================================
+
+
+class TestPongHandling:
+    """Test PONG message handling."""
+
+    @pytest.fixture
+    def server(self) -> RelayServer:
+        return RelayServer()
+
+    async def test_pong_sets_event(self, server: RelayServer) -> None:
+        """PONG message sets the pending pong event."""
+        instance = _make_instance()
+        event = asyncio.Event()
+        server._pending_pongs[instance.instance_id] = event
+
+        msg = {"type": MessageType.PONG.value}
+        await server._handle_unity_message(instance, msg)
+
+        assert event.is_set()
+
+    async def test_pong_without_pending_event_no_error(self, server: RelayServer) -> None:
+        """PONG when no event is pending does not raise."""
+        instance = _make_instance()
+
+        msg = {"type": MessageType.PONG.value}
+        await server._handle_unity_message(instance, msg)
+
+
+# =============================================================================
+# Unknown Message Type
+# =============================================================================
+
+
+class TestUnknownMessage:
+    """Test unknown Unity message type handling."""
+
+    @pytest.fixture
+    def server(self) -> RelayServer:
+        return RelayServer()
+
+    async def test_unknown_message_type_logged(self, server: RelayServer) -> None:
+        """Unknown message type is logged but does not raise."""
+        instance = _make_instance()
+
+        msg = {"type": "UNKNOWN_TYPE", "data": {}}
+        # Should not raise
+        await server._handle_unity_message(instance, msg)
+
+
+# =============================================================================
+# Heartbeat Logic
+# =============================================================================
+
+
+class TestHeartbeat:
+    """Test heartbeat-related constants and timeout detection."""
+
+    def test_heartbeat_timeout_not_expired(self) -> None:
+        """Fresh instance does not trigger timeout."""
+        _make_instance()
+        elapsed = 0.0
+        elapsed_ms = elapsed * 1000
+        assert elapsed_ms <= HEARTBEAT_TIMEOUT_MS
+
+    def test_heartbeat_timeout_extended_during_reloading(self) -> None:
+        """RELOADING state uses RELOAD_TIMEOUT_MS for timeout."""
+        assert RELOAD_TIMEOUT_MS > HEARTBEAT_TIMEOUT_MS
+
+    async def test_heartbeat_loop_disconnects_after_max_retries(self) -> None:
+        """Heartbeat loop breaks after HEARTBEAT_MAX_RETRIES consecutive failures."""
+        server = RelayServer()
+        server._running = True
+
+        instance = _make_instance()
+        server.registry._instances[instance.instance_id] = instance
+
+        # Mock write_frame to succeed but never send PONG (always timeout)
+        call_count = 0
+
+        async def fake_sleep(duration: float) -> None:
+            nonlocal call_count
+            call_count += 1
+            # Don't actually sleep
+
+        with (
+            patch("relay.server.write_frame", new_callable=AsyncMock),
+            patch("asyncio.sleep", side_effect=fake_sleep),
+            patch("asyncio.wait_for", side_effect=TimeoutError),
+        ):
+            await server._heartbeat_loop(instance.instance_id)
+
+        # Should have attempted HEARTBEAT_MAX_RETRIES pings
+        assert call_count == HEARTBEAT_MAX_RETRIES
+
+    async def test_heartbeat_loop_resets_failure_count_on_pong(self) -> None:
+        """Successful PONG resets consecutive failure counter."""
+        server = RelayServer()
+        server._running = True
+
+        instance = _make_instance()
+        server.registry._instances[instance.instance_id] = instance
+
+        iteration = 0
+
+        async def fake_sleep(duration: float) -> None:
+            nonlocal iteration
+            iteration += 1
+            # Stop after 3 iterations
+            if iteration >= 3:
+                server._running = False
+
+        async def fake_wait_for(coro, timeout: float) -> None:
+            # Always succeed (PONG received)
+            pass
+
+        with (
+            patch("relay.server.write_frame", new_callable=AsyncMock),
+            patch("asyncio.sleep", side_effect=fake_sleep),
+            patch("asyncio.wait_for", side_effect=fake_wait_for),
+        ):
+            await server._heartbeat_loop(instance.instance_id)
+
+        # Completed 3 iterations without disconnect
+        assert iteration == 3
+
+
+# =============================================================================
+# Command Queueing
+# =============================================================================
+
+
+class TestCommandQueueing:
+    """Test command queue behavior when instance is BUSY."""
+
+    def test_enqueue_when_queue_disabled_fails(self) -> None:
+        """Enqueue fails when queue_enabled is False."""
+        instance = _make_instance(queue_enabled=False)
+        future: asyncio.Future[dict] = asyncio.get_event_loop().create_future()
+        cmd = QueuedCommand(
+            request_id="req-1",
+            command="test",
+            params={},
+            timeout_ms=COMMAND_TIMEOUT_MS,
+            future=future,
+        )
+        assert instance.enqueue_command(cmd) is False
+
+    def test_enqueue_when_queue_enabled_succeeds(self) -> None:
+        """Enqueue succeeds when queue_enabled is True."""
+        instance = _make_instance(queue_enabled=True)
+        future: asyncio.Future[dict] = asyncio.get_event_loop().create_future()
+        cmd = QueuedCommand(
+            request_id="req-1",
+            command="test",
+            params={},
+            timeout_ms=COMMAND_TIMEOUT_MS,
+            future=future,
+        )
+        assert instance.enqueue_command(cmd) is True
+        assert instance.queue_size == 1
+
+    def test_enqueue_fails_when_queue_full(self) -> None:
+        """Enqueue fails when queue is at max capacity."""
+        from relay.instance_registry import QUEUE_MAX_SIZE
+
+        instance = _make_instance(queue_enabled=True)
+
+        # Fill the queue
+        for i in range(QUEUE_MAX_SIZE):
+            future: asyncio.Future[dict] = asyncio.get_event_loop().create_future()
+            cmd = QueuedCommand(
+                request_id=f"req-{i}",
+                command="test",
+                params={},
+                timeout_ms=COMMAND_TIMEOUT_MS,
+                future=future,
+            )
+            assert instance.enqueue_command(cmd) is True
+
+        # Next enqueue should fail
+        overflow_future: asyncio.Future[dict] = asyncio.get_event_loop().create_future()
+        overflow_cmd = QueuedCommand(
+            request_id="req-overflow",
+            command="test",
+            params={},
+            timeout_ms=COMMAND_TIMEOUT_MS,
+            future=overflow_future,
+        )
+        assert instance.enqueue_command(overflow_cmd) is False
+
+    def test_dequeue_fifo_order(self) -> None:
+        """Commands are dequeued in FIFO order."""
+        instance = _make_instance(queue_enabled=True)
+
+        for i in range(3):
+            future: asyncio.Future[dict] = asyncio.get_event_loop().create_future()
+            cmd = QueuedCommand(
+                request_id=f"req-{i}",
+                command="test",
+                params={},
+                timeout_ms=COMMAND_TIMEOUT_MS,
+                future=future,
+            )
+            instance.enqueue_command(cmd)
+
+        actual = [instance.dequeue_command().request_id for _ in range(3)]
+        assert actual == ["req-0", "req-1", "req-2"]
+
+    def test_dequeue_empty_returns_none(self) -> None:
+        """Dequeue from empty queue returns None."""
+        instance = _make_instance(queue_enabled=True)
+        assert instance.dequeue_command() is None
+
+    async def test_process_queue_sends_next_command(self) -> None:
+        """_process_queue executes the next queued command."""
+        server = RelayServer()
+        instance = _make_instance(queue_enabled=True)
+        server.registry._instances[instance.instance_id] = instance
+
+        future: asyncio.Future[dict] = asyncio.get_event_loop().create_future()
+        cmd = QueuedCommand(
+            request_id="req-queued",
+            command="test_cmd",
+            params={"key": "value"},
+            timeout_ms=COMMAND_TIMEOUT_MS,
+            future=future,
+        )
+        instance.enqueue_command(cmd)
+
+        mock_result = {"type": "RESPONSE", "success": True, "data": {"result": "ok"}}
+        with patch.object(server, "_execute_command", new_callable=AsyncMock, return_value=mock_result):
+            await server._process_queue(instance)
+
+        assert future.done()
+        assert future.result() == mock_result
+
+    async def test_process_queue_skips_done_future(self) -> None:
+        """_process_queue skips commands whose futures are already done (timed out)."""
+        server = RelayServer()
+        instance = _make_instance(queue_enabled=True)
+        server.registry._instances[instance.instance_id] = instance
+
+        # First command: already timed out
+        done_future: asyncio.Future[dict] = asyncio.get_event_loop().create_future()
+        done_future.set_result({"timeout": True})  # Mark as done
+        timed_out_cmd = QueuedCommand(
+            request_id="req-timed-out",
+            command="old_cmd",
+            params={},
+            timeout_ms=COMMAND_TIMEOUT_MS,
+            future=done_future,
+        )
+        instance.enqueue_command(timed_out_cmd)
+
+        # Second command: still pending
+        pending_future: asyncio.Future[dict] = asyncio.get_event_loop().create_future()
+        pending_cmd = QueuedCommand(
+            request_id="req-pending",
+            command="new_cmd",
+            params={},
+            timeout_ms=COMMAND_TIMEOUT_MS,
+            future=pending_future,
+        )
+        instance.enqueue_command(pending_cmd)
+
+        mock_result = {"type": "RESPONSE", "success": True, "data": {}}
+        with patch.object(server, "_execute_command", new_callable=AsyncMock, return_value=mock_result):
+            await server._process_queue(instance)
+
+        # The timed out one should be skipped; the pending one should be resolved
+        assert pending_future.done()
+        assert pending_future.result() == mock_result
+
+    async def test_process_queue_noop_when_empty(self) -> None:
+        """_process_queue does nothing when queue is empty."""
+        server = RelayServer()
+        instance = _make_instance(queue_enabled=True)
+
+        with patch.object(server, "_execute_command", new_callable=AsyncMock) as mock_exec:
+            await server._process_queue(instance)
+            mock_exec.assert_not_awaited()
+
+    async def test_process_queue_noop_when_disabled(self) -> None:
+        """_process_queue does nothing when queue is disabled."""
+        server = RelayServer()
+        instance = _make_instance(queue_enabled=False)
+
+        with patch.object(server, "_execute_command", new_callable=AsyncMock) as mock_exec:
+            await server._process_queue(instance)
+            mock_exec.assert_not_awaited()
+
+    def test_flush_queue_resolves_all_futures(self) -> None:
+        """flush_queue resolves all pending futures with error."""
+        instance = _make_instance(queue_enabled=True)
+
+        futures = []
+        for i in range(3):
+            future: asyncio.Future[dict] = asyncio.get_event_loop().create_future()
+            cmd = QueuedCommand(
+                request_id=f"req-{i}",
+                command="test",
+                params={},
+                timeout_ms=COMMAND_TIMEOUT_MS,
+                future=future,
+            )
+            instance.enqueue_command(cmd)
+            futures.append(future)
+
+        instance.flush_queue("INSTANCE_DISCONNECTED", "Instance disconnected")
+
+        for f in futures:
+            assert f.done()
+            result = f.result()
+            assert result["type"] == "ERROR"
+            assert result["error"]["code"] == "INSTANCE_DISCONNECTED"
+
+        assert instance.queue_size == 0
+
+
+# =============================================================================
+# CLI Message Handling
+# =============================================================================
+
+
+class TestCLIMessageHandling:
+    """Test _handle_cli_message for various CLI message types."""
+
+    @pytest.fixture
+    def server(self) -> RelayServer:
+        return RelayServer()
+
+    async def test_list_instances_returns_instances_message(self, server: RelayServer) -> None:
+        """LIST_INSTANCES returns INSTANCES response."""
+        writer = _make_writer()
+        msg = {"type": MessageType.LIST_INSTANCES.value, "id": "req-list"}
+
+        with patch("relay.server.write_frame", new_callable=AsyncMock) as mock_write:
+            await server._handle_cli_message(writer, msg)
+
+            mock_write.assert_awaited_once()
+            response = mock_write.call_args[0][1]
+            assert response["type"] == "INSTANCES"
+            assert response["success"] is True
+
+    async def test_set_default_nonexistent_returns_error(self, server: RelayServer) -> None:
+        """SET_DEFAULT for nonexistent instance returns error."""
+        writer = _make_writer()
+        msg = {
+            "type": MessageType.SET_DEFAULT.value,
+            "id": "req-set",
+            "instance": "/nonexistent",
+        }
+
+        with patch("relay.server.write_frame", new_callable=AsyncMock) as mock_write:
+            await server._handle_cli_message(writer, msg)
+
+            response = mock_write.call_args[0][1]
+            assert response["type"] == "ERROR"
+            assert response["error"]["code"] == ErrorCode.INSTANCE_NOT_FOUND.value
+
+    async def test_unknown_cli_message_type_returns_error(self, server: RelayServer) -> None:
+        """Unknown CLI message type returns PROTOCOL_ERROR."""
+        writer = _make_writer()
+        msg = {"type": "INVALID_TYPE", "id": "req-x"}
+
+        with patch("relay.server.write_frame", new_callable=AsyncMock) as mock_write:
+            await server._handle_cli_message(writer, msg)
+
+            response = mock_write.call_args[0][1]
+            assert response["type"] == "ERROR"
+            assert response["error"]["code"] == ErrorCode.PROTOCOL_ERROR.value
+
+
+# =============================================================================
+# Execute Command
+# =============================================================================
+
+
+class TestExecuteCommand:
+    """Test _execute_command with various instance states."""
+
+    @pytest.fixture
+    def server(self) -> RelayServer:
+        return RelayServer()
+
+    async def test_capability_check_rejects_unsupported(self, server: RelayServer) -> None:
+        """Command not in capabilities list returns CAPABILITY_NOT_SUPPORTED."""
+        instance = _make_instance()
+        instance.capabilities = ["manage_editor", "get_console"]
+        server.registry._instances[instance.instance_id] = instance
+        server.registry._default_instance_id = instance.instance_id
+
+        result = await server._execute_command(
+            request_id="req-cap",
+            instance_id=None,
+            command="unsupported_command",
+            params={},
+            timeout_ms=COMMAND_TIMEOUT_MS,
+        )
+
+        assert result["type"] == "ERROR"
+        assert result["error"]["code"] == ErrorCode.CAPABILITY_NOT_SUPPORTED.value
+
+    async def test_no_instance_returns_not_found(self, server: RelayServer) -> None:
+        """No instances registered returns INSTANCE_NOT_FOUND."""
+        result = await server._execute_command(
+            request_id="req-none",
+            instance_id="/nonexistent",
+            command="test",
+            params={},
+            timeout_ms=COMMAND_TIMEOUT_MS,
+        )
+
+        assert result["type"] == "ERROR"
+        assert result["error"]["code"] == ErrorCode.INSTANCE_NOT_FOUND.value
+
+    async def test_busy_instance_without_queue_returns_busy(self, server: RelayServer) -> None:
+        """BUSY instance with queue disabled returns INSTANCE_BUSY."""
+        instance = _make_instance(status=InstanceStatus.BUSY, queue_enabled=False)
+        server.registry._instances[instance.instance_id] = instance
+        server.registry._default_instance_id = instance.instance_id
+
+        result = await server._execute_command(
+            request_id="req-busy",
+            instance_id=None,
+            command="test",
+            params={},
+            timeout_ms=COMMAND_TIMEOUT_MS,
+        )
+
+        assert result["type"] == "ERROR"
+        assert result["error"]["code"] == ErrorCode.INSTANCE_BUSY.value
+
+
+# =============================================================================
+# Server Lifecycle
+# =============================================================================
+
+
+class TestServerLifecycle:
+    """Test server start/stop behavior."""
+
+    async def test_stop_is_idempotent(self) -> None:
+        """Calling stop() multiple times is safe."""
+        server = RelayServer()
+        server._running = True
+        await server.request_cache.start()
+
+        await server.stop()
+        assert server._stopped is True
+
+        # Second stop should be a no-op
+        await server.stop()
+        assert server._stopped is True
+
+    async def test_stop_cancels_heartbeat_tasks(self) -> None:
+        """stop() cancels all heartbeat tasks."""
+        server = RelayServer()
+        server._running = True
+        await server.request_cache.start()
+
+        # Create a fake heartbeat task
+        task = asyncio.create_task(asyncio.sleep(999))
+        server._heartbeat_tasks["test-instance"] = task
+
+        await server.stop()
+
+        assert len(server._heartbeat_tasks) == 0
+        assert task.cancelled()
+
+    async def test_stop_cancels_pending_commands(self) -> None:
+        """stop() cancels all pending command futures."""
+        server = RelayServer()
+        server._running = True
+        await server.request_cache.start()
+
+        future: asyncio.Future[dict] = asyncio.get_event_loop().create_future()
+        server._pending_commands["req-pending"] = future
+
+        await server.stop()
+
+        assert len(server._pending_commands) == 0
+        assert future.cancelled()

--- a/tests/test_scene_api.py
+++ b/tests/test_scene_api.py
@@ -10,12 +10,6 @@ from unity_cli.api.scene import SceneAPI
 
 
 @pytest.fixture
-def mock_conn() -> MagicMock:
-    """Create a mock relay connection."""
-    return MagicMock()
-
-
-@pytest.fixture
 def sut(mock_conn: MagicMock) -> SceneAPI:
     """Create a SceneAPI instance with mock connection."""
     return SceneAPI(mock_conn)

--- a/tests/test_screenshot_api.py
+++ b/tests/test_screenshot_api.py
@@ -1,0 +1,224 @@
+"""Tests for unity_cli/api/screenshot.py - Screenshot API"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from unity_cli.api.screenshot import ScreenshotAPI
+
+
+@pytest.fixture
+def mock_conn() -> MagicMock:
+    """Create a mock relay connection."""
+    return MagicMock()
+
+
+@pytest.fixture
+def sut(mock_conn: MagicMock) -> ScreenshotAPI:
+    """Create a ScreenshotAPI instance with mock connection."""
+    return ScreenshotAPI(mock_conn)
+
+
+class TestCapture:
+    """capture() メソッドのテスト"""
+
+    def test_sends_screenshot_command(self, sut: ScreenshotAPI, mock_conn: MagicMock) -> None:
+        """Send 'screenshot' as the command name."""
+        mock_conn.send_request.return_value = {}
+
+        sut.capture()
+
+        assert mock_conn.send_request.call_args[0][0] == "screenshot"
+
+    def test_sends_capture_action(self, sut: ScreenshotAPI, mock_conn: MagicMock) -> None:
+        """Send action='capture'。"""
+        mock_conn.send_request.return_value = {}
+
+        sut.capture()
+
+        params = mock_conn.send_request.call_args[0][1]
+        assert params["action"] == "capture"
+
+    def test_default_params(self, sut: ScreenshotAPI, mock_conn: MagicMock) -> None:
+        """デフォルトパラメータの確認。"""
+        mock_conn.send_request.return_value = {}
+
+        sut.capture()
+
+        params = mock_conn.send_request.call_args[0][1]
+        assert params["source"] == "game"
+        assert params["superSize"] == 1
+
+    @pytest.mark.parametrize(
+        "source",
+        ["game", "scene", "camera"],
+    )
+    def test_source_param(self, sut: ScreenshotAPI, mock_conn: MagicMock, source: str) -> None:
+        """各 source が正しく送信される。"""
+        mock_conn.send_request.return_value = {}
+
+        sut.capture(source=source)  # type: ignore[arg-type]
+
+        params = mock_conn.send_request.call_args[0][1]
+        assert params["source"] == source
+
+    def test_path_included_when_set(self, sut: ScreenshotAPI, mock_conn: MagicMock) -> None:
+        """path 指定時にパラメータに含まれる。"""
+        mock_conn.send_request.return_value = {}
+
+        sut.capture(path="/tmp/shot.png")
+
+        params = mock_conn.send_request.call_args[0][1]
+        assert params["path"] == "/tmp/shot.png"
+
+    def test_path_excluded_when_none(self, sut: ScreenshotAPI, mock_conn: MagicMock) -> None:
+        """path=None の場合パラメータに含まれない。"""
+        mock_conn.send_request.return_value = {}
+
+        sut.capture()
+
+        params = mock_conn.send_request.call_args[0][1]
+        assert "path" not in params
+
+    @pytest.mark.parametrize(
+        ("param_name", "kwarg", "api_key"),
+        [
+            ("width", {"width": 3840}, "width"),
+            ("height", {"height": 2160}, "height"),
+            ("camera", {"camera": "MyCam"}, "camera"),
+            ("format", {"format": "jpg"}, "format"),
+            ("quality", {"quality": 95}, "quality"),
+        ],
+    )
+    def test_optional_params_included_when_set(
+        self,
+        sut: ScreenshotAPI,
+        mock_conn: MagicMock,
+        param_name: str,
+        kwarg: dict,
+        api_key: str,
+    ) -> None:
+        """オプションパラメータが設定時にのみ含まれる。"""
+        mock_conn.send_request.return_value = {}
+
+        sut.capture(**kwarg)  # type: ignore[arg-type]
+
+        params = mock_conn.send_request.call_args[0][1]
+        assert api_key in params
+
+    @pytest.mark.parametrize(
+        "param_key",
+        ["width", "height", "camera", "format", "quality"],
+    )
+    def test_optional_params_excluded_when_none(self, sut: ScreenshotAPI, mock_conn: MagicMock, param_key: str) -> None:
+        """デフォルト None のオプションパラメータはリクエストに含まれない。"""
+        mock_conn.send_request.return_value = {}
+
+        sut.capture()
+
+        params = mock_conn.send_request.call_args[0][1]
+        assert param_key not in params
+
+    def test_returns_response(self, sut: ScreenshotAPI, mock_conn: MagicMock) -> None:
+        """send_request の戻り値をそのまま返す。"""
+        expected = {"path": "/tmp/shot.png", "source": "game"}
+        mock_conn.send_request.return_value = expected
+
+        result = sut.capture()
+        assert result == expected
+
+
+class TestBurst:
+    """burst() メソッドのテスト"""
+
+    def test_sends_screenshot_command(self, sut: ScreenshotAPI, mock_conn: MagicMock) -> None:
+        """Send 'screenshot' as the command name."""
+        mock_conn.send_request.return_value = {}
+
+        sut.burst()
+
+        assert mock_conn.send_request.call_args[0][0] == "screenshot"
+
+    def test_sends_burst_action(self, sut: ScreenshotAPI, mock_conn: MagicMock) -> None:
+        """Send action='burst'。"""
+        mock_conn.send_request.return_value = {}
+
+        sut.burst()
+
+        params = mock_conn.send_request.call_args[0][1]
+        assert params["action"] == "burst"
+
+    def test_default_params(self, sut: ScreenshotAPI, mock_conn: MagicMock) -> None:
+        """デフォルトパラメータの確認。"""
+        mock_conn.send_request.return_value = {}
+
+        sut.burst()
+
+        params = mock_conn.send_request.call_args[0][1]
+        assert params["count"] == 10
+        assert params["interval_ms"] == 0
+        assert params["format"] == "jpg"
+        assert params["quality"] == 75
+        assert params["width"] == 1920
+        assert params["height"] == 1080
+
+    def test_custom_params(self, sut: ScreenshotAPI, mock_conn: MagicMock) -> None:
+        """カスタムパラメータが正しく送信される。"""
+        mock_conn.send_request.return_value = {}
+
+        sut.burst(count=100, interval_ms=50, format="png", quality=100, width=3840, height=2160)
+
+        params = mock_conn.send_request.call_args[0][1]
+        assert params["count"] == 100
+        assert params["interval_ms"] == 50
+        assert params["format"] == "png"
+
+    def test_camera_included_when_set(self, sut: ScreenshotAPI, mock_conn: MagicMock) -> None:
+        mock_conn.send_request.return_value = {}
+
+        sut.burst(camera="OverviewCam")
+
+        params = mock_conn.send_request.call_args[0][1]
+        assert params["camera"] == "OverviewCam"
+
+    def test_camera_excluded_when_none(self, sut: ScreenshotAPI, mock_conn: MagicMock) -> None:
+        mock_conn.send_request.return_value = {}
+
+        sut.burst()
+
+        params = mock_conn.send_request.call_args[0][1]
+        assert "camera" not in params
+
+    def test_output_dir_included_when_set(self, sut: ScreenshotAPI, mock_conn: MagicMock) -> None:
+        mock_conn.send_request.return_value = {}
+
+        sut.burst(output_dir="/tmp/burst")
+
+        params = mock_conn.send_request.call_args[0][1]
+        assert params["outputDir"] == "/tmp/burst"
+
+    def test_output_dir_excluded_when_none(self, sut: ScreenshotAPI, mock_conn: MagicMock) -> None:
+        mock_conn.send_request.return_value = {}
+
+        sut.burst()
+
+        params = mock_conn.send_request.call_args[0][1]
+        assert "outputDir" not in params
+
+    def test_timeout_ms_120000(self, sut: ScreenshotAPI, mock_conn: MagicMock) -> None:
+        """burst は timeout_ms=120000 で送信。"""
+        mock_conn.send_request.return_value = {}
+
+        sut.burst()
+
+        kwargs = mock_conn.send_request.call_args[1]
+        assert kwargs["timeout_ms"] == 120000
+
+    def test_returns_response(self, sut: ScreenshotAPI, mock_conn: MagicMock) -> None:
+        expected = {"frameCount": 10, "outputDir": "/tmp/burst", "fps": 60.0}
+        mock_conn.send_request.return_value = expected
+
+        result = sut.burst()
+        assert result == expected

--- a/tests/test_selection_api.py
+++ b/tests/test_selection_api.py
@@ -10,12 +10,6 @@ from unity_cli.api.selection import SelectionAPI
 
 
 @pytest.fixture
-def mock_conn() -> MagicMock:
-    """Create a mock relay connection."""
-    return MagicMock()
-
-
-@pytest.fixture
 def sut(mock_conn: MagicMock) -> SelectionAPI:
     """Create a SelectionAPI instance with mock connection."""
     return SelectionAPI(mock_conn)

--- a/tests/test_tests_api.py
+++ b/tests/test_tests_api.py
@@ -10,12 +10,6 @@ from unity_cli.api.tests import TestAPI
 
 
 @pytest.fixture
-def mock_conn() -> MagicMock:
-    """Create a mock relay connection."""
-    return MagicMock()
-
-
-@pytest.fixture
 def sut(mock_conn: MagicMock) -> TestAPI:
     """Create a TestAPI instance with mock connection."""
     return TestAPI(mock_conn)

--- a/tests/test_uitree_api.py
+++ b/tests/test_uitree_api.py
@@ -10,11 +10,6 @@ from unity_cli.api.uitree import UITreeAPI, _strip_panel_count
 
 
 @pytest.fixture
-def mock_conn() -> MagicMock:
-    return MagicMock()
-
-
-@pytest.fixture
 def sut(mock_conn: MagicMock) -> UITreeAPI:
     return UITreeAPI(mock_conn)
 


### PR DESCRIPTION
## Summary

- pytest-cov導入、CIにカバレッジ計測(`--cov-fail-under=60`)とHTMLレポートartifactを追加
- ルート`tests/conftest.py`を新設し、12ファイルの重複`mock_conn` fixtureを集約
- relay server状態遷移・clientリトライ・characterizationテストを追加(142テスト)
- 未テストだったmodels, exceptions, config, hub, API, CLIコマンドのテストを追加(214テスト)

Before: 550 tests, カバレッジ計測なし
After: 946 tests, 62.44% (`--cov-fail-under=60`)

## Test plan

- [x] `uv run python -m pytest tests/ -m "not integration" --cov-fail-under=60` → 946 passed, 62.44%
- [ ] CI green確認