### PR TITLE
🐛 fix: Bridge のメインスレッドディスパッチ修正と送信経路の堅牢化

### DIFF
--- a/TestProject/Assets/Tests/Editor/BridgeManagerThreadingTests.cs
+++ b/TestProject/Assets/Tests/Editor/BridgeManagerThreadingTests.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections.Generic;
-using System.Reflection;
 using System.Threading;
 using System.Threading.Tasks;
 using Newtonsoft.Json.Linq;
@@ -82,12 +81,7 @@ namespace UnityBridge
         }
 
         private static bool GetUpdateRegistered(BridgeManager manager)
-        {
-            var field = typeof(BridgeManager).GetField("_updateRegistered",
-                BindingFlags.NonPublic | BindingFlags.Instance);
-            Assert.That(field, Is.Not.Null, "_updateRegistered フィールドが存在すること。");
-            return (bool)field!.GetValue(manager);
-        }
+            => manager.IsUpdateRegistered;
 
         private sealed class StubCommandDispatcher : ICommandDispatcher
         {

--- a/TestProject/Assets/Tests/Editor/BridgeManagerThreadingTests.cs
+++ b/TestProject/Assets/Tests/Editor/BridgeManagerThreadingTests.cs
@@ -65,6 +65,22 @@ namespace UnityBridge
             }
         }
 
+        [Test]
+        public void ConnectAsync_WhenClientConnectThrows_RollsBackState()
+        {
+            var stubClient = new StubRelayClient { ConnectThrows = true };
+            var manager = new BridgeManager(new StubCommandDispatcher(), (_, _) => stubClient);
+
+            Assert.ThrowsAsync<InvalidOperationException>(async () => await manager.ConnectAsync());
+
+            Assert.That(GetUpdateRegistered(manager), Is.False,
+                "ConnectAsync が失敗した場合、UnregisterUpdate でハンドラ登録が解除されていること。");
+            Assert.That(manager.Client, Is.Null,
+                "ConnectAsync が失敗した場合、Client プロパティは null に戻っていること。");
+            Assert.That(stubClient.DisposeCalled, Is.True,
+                "ConnectAsync が失敗した場合、Client.DisposeAsync が呼ばれていること。");
+        }
+
         private static bool GetUpdateRegistered(BridgeManager manager)
         {
             var field = typeof(BridgeManager).GetField("_updateRegistered",
@@ -90,11 +106,17 @@ namespace UnityBridge
             public string UnityVersion => "6000.0.0f1";
             public string[] Capabilities { get; set; } = Array.Empty<string>();
 
+            public bool ConnectThrows { get; set; }
+            public bool DisposeCalled { get; private set; }
+
             public event EventHandler<ConnectionStatusChangedEventArgs> StatusChanged;
             public event EventHandler<CommandReceivedEventArgs> CommandReceived;
 
             public Task ConnectAsync(CancellationToken cancellationToken = default)
             {
+                if (ConnectThrows)
+                    throw new InvalidOperationException("stub connect failure");
+
                 IsConnected = true;
                 StatusChanged?.Invoke(this,
                     new ConnectionStatusChangedEventArgs(ConnectionStatus.Disconnected, ConnectionStatus.Connected));
@@ -112,8 +134,8 @@ namespace UnityBridge
             public Task SendReadyStatusAsync() => Task.CompletedTask;
             public Task SendCommandResultAsync(string id, JObject data) => Task.CompletedTask;
             public Task SendCommandErrorAsync(string id, string code, string message) => Task.CompletedTask;
-            public void Dispose() { }
-            public ValueTask DisposeAsync() => default;
+            public void Dispose() { DisposeCalled = true; }
+            public ValueTask DisposeAsync() { DisposeCalled = true; return default; }
         }
     }
 }

--- a/TestProject/Assets/Tests/Editor/BridgeManagerThreadingTests.cs
+++ b/TestProject/Assets/Tests/Editor/BridgeManagerThreadingTests.cs
@@ -1,0 +1,119 @@
+using System;
+using System.Collections.Generic;
+using System.Reflection;
+using System.Threading;
+using System.Threading.Tasks;
+using Newtonsoft.Json.Linq;
+using NUnit.Framework;
+
+namespace UnityBridge
+{
+    /// <summary>
+    /// BridgeManager のスレッディング契約を検証するテスト。
+    ///
+    /// 背景: <see cref="BridgeManager.OnCommandReceived"/> は <see cref="RelayClient.ReceiveLoopAsync"/>
+    /// から発火するためバックグラウンドスレッド上で呼ばれる。Unity の <c>EditorApplication</c> 系 API は
+    /// メインスレッド専用で、バックグラウンドスレッドからの呼び出しは例外を出さずに無視されるため、
+    /// <c>EditorApplication.update</c> へのハンドラ登録は接続時 (メインスレッド) に済ませておく必要がある。
+    /// </summary>
+    [TestFixture]
+    public class BridgeManagerThreadingTests
+    {
+        [Test]
+        public async Task ConnectAsync_RegistersEditorApplicationUpdate_OnConnect()
+        {
+            var stubClient = new StubRelayClient();
+            var manager = new BridgeManager(new StubCommandDispatcher(), (_, _) => stubClient);
+
+            try
+            {
+                await manager.ConnectAsync();
+
+                Assert.That(GetUpdateRegistered(manager), Is.True,
+                    "ConnectAsync は EditorApplication.update へのハンドラ登録をメインスレッドで完了させること。");
+            }
+            finally
+            {
+                await manager.DisconnectAsync();
+            }
+        }
+
+        [Test]
+        public async Task ConnectAsync_AfterDisconnect_ReRegistersEditorApplicationUpdate()
+        {
+            var stubClient1 = new StubRelayClient();
+            var stubClient2 = new StubRelayClient();
+            var clients = new Queue<IRelayClient>(new IRelayClient[] { stubClient1, stubClient2 });
+            var manager = new BridgeManager(new StubCommandDispatcher(), (_, _) => clients.Dequeue());
+
+            try
+            {
+                await manager.ConnectAsync();
+                await manager.DisconnectAsync();
+
+                Assert.That(GetUpdateRegistered(manager), Is.False,
+                    "DisconnectAsync 後はハンドラ登録が解除されていること。");
+
+                await manager.ConnectAsync();
+
+                Assert.That(GetUpdateRegistered(manager), Is.True,
+                    "再接続時に EditorApplication.update へのハンドラが再登録されること。");
+            }
+            finally
+            {
+                await manager.DisconnectAsync();
+            }
+        }
+
+        private static bool GetUpdateRegistered(BridgeManager manager)
+        {
+            var field = typeof(BridgeManager).GetField("_updateRegistered",
+                BindingFlags.NonPublic | BindingFlags.Instance);
+            Assert.That(field, Is.Not.Null, "_updateRegistered フィールドが存在すること。");
+            return (bool)field!.GetValue(manager);
+        }
+
+        private sealed class StubCommandDispatcher : ICommandDispatcher
+        {
+            public IEnumerable<string> RegisteredCommands => Array.Empty<string>();
+            public void Initialize() { }
+            public Task<JObject> ExecuteAsync(string commandName, JObject parameters)
+                => Task.FromResult(new JObject());
+        }
+
+        private sealed class StubRelayClient : IRelayClient
+        {
+            public string InstanceId => "/stub/project";
+            public bool IsConnected { get; private set; }
+            public ConnectionStatus Status => IsConnected ? ConnectionStatus.Connected : ConnectionStatus.Disconnected;
+            public string ProjectName => "StubProject";
+            public string UnityVersion => "6000.0.0f1";
+            public string[] Capabilities { get; set; } = Array.Empty<string>();
+
+            public event EventHandler<ConnectionStatusChangedEventArgs> StatusChanged;
+            public event EventHandler<CommandReceivedEventArgs> CommandReceived;
+
+            public Task ConnectAsync(CancellationToken cancellationToken = default)
+            {
+                IsConnected = true;
+                StatusChanged?.Invoke(this,
+                    new ConnectionStatusChangedEventArgs(ConnectionStatus.Disconnected, ConnectionStatus.Connected));
+                return Task.CompletedTask;
+            }
+
+            public Task DisconnectAsync()
+            {
+                IsConnected = false;
+                return Task.CompletedTask;
+            }
+
+            public Task SendStatusAsync(string status, string detail = null) => Task.CompletedTask;
+            public Task SendReloadingStatusAsync() => Task.CompletedTask;
+            public Task SendReadyStatusAsync() => Task.CompletedTask;
+            public Task SendCommandResultAsync(string id, JObject data) => Task.CompletedTask;
+            public Task SendCommandErrorAsync(string id, string code, string message) => Task.CompletedTask;
+            public void Dispose() { }
+            public ValueTask DisposeAsync() => default;
+        }
+    }
+}

--- a/TestProject/Assets/Tests/Editor/BridgeManagerThreadingTests.cs.meta
+++ b/TestProject/Assets/Tests/Editor/BridgeManagerThreadingTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: a6bfe8cf0f3e4a79b6eb6d202d362733

--- a/UnityBridge/Editor/BridgeManager.cs
+++ b/UnityBridge/Editor/BridgeManager.cs
@@ -21,6 +21,12 @@ namespace UnityBridge
         private bool _isProcessing;
 
         /// <summary>
+        /// Whether the EditorApplication.update handler that drains the command queue
+        /// is currently registered. Exposed for tests so they do not need reflection.
+        /// </summary>
+        internal bool IsUpdateRegistered => _updateRegistered;
+
+        /// <summary>
         /// Singleton instance
         /// </summary>
         public static BridgeManager Instance

--- a/UnityBridge/Editor/BridgeManager.cs
+++ b/UnityBridge/Editor/BridgeManager.cs
@@ -99,6 +99,13 @@ namespace UnityBridge
             Client.StatusChanged += OnClientStatusChanged;
             Client.CommandReceived += OnCommandReceived;
 
+            // Register the EditorApplication.update handler on the main thread BEFORE
+            // the receive loop can start firing CommandReceived from a background thread.
+            // EditorApplication.update is silently no-op when assigned from a background
+            // thread, so registering it inside OnCommandReceived (which runs on the
+            // receive thread) does not work.
+            EnsureUpdateRegistered();
+
             await Client.ConnectAsync();
 
             // Register for reload handling
@@ -146,15 +153,14 @@ namespace UnityBridge
         {
             BridgeLog.Verbose($"Queuing command for main thread: {e.Command} (id: {e.Id})");
 
-            // Queue command for main thread execution
+            // This handler runs on the RelayClient receive thread (background).
+            // ConcurrentQueue.Enqueue is thread-safe; the EditorApplication.update
+            // handler registered during ConnectAsync drains the queue on the main thread.
+            //
+            // Do NOT call EditorApplication.* APIs here — they are silently ignored
+            // when called from background threads, which previously caused commands to
+            // pile up unprocessed and time out on the relay side.
             _commandQueue.Enqueue(e);
-
-            // Ensure update handler is registered
-            EnsureUpdateRegistered();
-
-            // Force editor to tick even when unfocused, so the command is processed immediately.
-            // Without this, EditorApplication.update stops firing when Unity loses focus.
-            EditorApplication.QueuePlayerLoopUpdate();
         }
 
         private void EnsureUpdateRegistered()

--- a/UnityBridge/Editor/BridgeManager.cs
+++ b/UnityBridge/Editor/BridgeManager.cs
@@ -95,9 +95,10 @@ namespace UnityBridge
             Host = host;
             Port = port;
 
-            Client = _clientFactory(host, port);
-            Client.StatusChanged += OnClientStatusChanged;
-            Client.CommandReceived += OnCommandReceived;
+            var client = _clientFactory(host, port);
+            client.StatusChanged += OnClientStatusChanged;
+            client.CommandReceived += OnCommandReceived;
+            Client = client;
 
             // Register the EditorApplication.update handler on the main thread BEFORE
             // the receive loop can start firing CommandReceived from a background thread.
@@ -106,7 +107,29 @@ namespace UnityBridge
             // receive thread) does not work.
             EnsureUpdateRegistered();
 
-            await Client.ConnectAsync();
+            try
+            {
+                await client.ConnectAsync();
+            }
+            catch
+            {
+                // Roll back partial setup so a retry starts from a clean state.
+                client.StatusChanged -= OnClientStatusChanged;
+                client.CommandReceived -= OnCommandReceived;
+                UnregisterUpdate();
+                Client = null;
+
+                try
+                {
+                    await client.DisposeAsync().ConfigureAwait(false);
+                }
+                catch (Exception disposeEx)
+                {
+                    BridgeLog.Warn($"Dispose error during ConnectAsync rollback (ignored): {disposeEx.Message}");
+                }
+
+                throw;
+            }
 
             // Register for reload handling
             BridgeReloadHandler.RegisterClient(Client, host, port);

--- a/UnityBridge/Editor/Helpers/BridgeLog.cs
+++ b/UnityBridge/Editor/Helpers/BridgeLog.cs
@@ -1,4 +1,5 @@
 using System.Diagnostics;
+using System.Threading;
 using UnityEditor;
 using Debug = UnityEngine.Debug;
 
@@ -27,13 +28,38 @@ namespace UnityBridge.Helpers
 
         private const string EnabledKey = "UnityBridge.LogEnabled";
 
+        // EditorPrefs is main-thread only. The send path in RelayClient runs
+        // continuations on the thread pool (ConfigureAwait(false)) so PONG cannot be
+        // starved by a stalled main thread, which means BridgeLog must be safe to call
+        // from any thread. Cache the toggle here and refresh it on the main thread via
+        // [InitializeOnLoadMethod] and the setter.
+        private static int _enabledCache = 1;
+
+        [InitializeOnLoadMethod]
+        private static void RefreshEnabledCache()
+        {
+            try
+            {
+                Volatile.Write(ref _enabledCache, EditorPrefs.GetBool(EnabledKey, true) ? 1 : 0);
+            }
+            catch
+            {
+                // Fall back to enabled if EditorPrefs is unavailable (e.g. batch mode init order)
+                Volatile.Write(ref _enabledCache, 1);
+            }
+        }
+
         /// <summary>
         /// Enable or disable all console logging.
         /// </summary>
         public static bool Enabled
         {
-            get => EditorPrefs.GetBool(EnabledKey, true);
-            set => EditorPrefs.SetBool(EnabledKey, value);
+            get => Volatile.Read(ref _enabledCache) != 0;
+            set
+            {
+                EditorPrefs.SetBool(EnabledKey, value);
+                Volatile.Write(ref _enabledCache, value ? 1 : 0);
+            }
         }
 
         /// <summary>

--- a/UnityBridge/Editor/RelayClient.cs
+++ b/UnityBridge/Editor/RelayClient.cs
@@ -270,7 +270,9 @@ namespace UnityBridge
             }
             try
             {
-                await Framing.WriteFrameAsync(_stream, statusMsg).ConfigureAwait(false);
+                // Pass the token so a Disconnect cancels an in-flight write instead of
+                // letting NetworkStream.WriteAsync hang while holding _sendLock.
+                await Framing.WriteFrameAsync(_stream, statusMsg, token).ConfigureAwait(false);
             }
             finally
             {
@@ -328,13 +330,17 @@ namespace UnityBridge
 
             try
             {
+                var token = _cts?.Token ?? CancellationToken.None;
+
                 // ConfigureAwait(false) keeps the lock-holding continuation off the
                 // Unity main thread so a non-focused editor cannot stall this send
                 // and starve PONG / STATUS waiting on _sendLock.
-                await _sendLock.WaitAsync(_cts?.Token ?? CancellationToken.None).ConfigureAwait(false);
+                await _sendLock.WaitAsync(token).ConfigureAwait(false);
                 try
                 {
-                    await Framing.WriteFrameAsync(_stream, message).ConfigureAwait(false);
+                    // Pass the token so a Disconnect cancels an in-flight write instead
+                    // of letting NetworkStream.WriteAsync hang while holding _sendLock.
+                    await Framing.WriteFrameAsync(_stream, message, token).ConfigureAwait(false);
                 }
                 finally
                 {

--- a/UnityBridge/Editor/RelayClient.cs
+++ b/UnityBridge/Editor/RelayClient.cs
@@ -66,6 +66,12 @@ namespace UnityBridge
         private readonly SemaphoreSlim _sendLock = new(1, 1);
         private bool _disposed;
 
+        // Upper bound on _sendLock waits for latency-sensitive sends. PONG must
+        // respond before the relay heartbeat window expires; STATUS is informational
+        // and can be dropped on timeout.
+        private const int PongLockTimeoutMs = 3000;
+        private const int StatusLockTimeoutMs = 5000;
+
         private readonly string _host;
         private readonly int _port;
         private int _heartbeatIntervalMs = ProtocolConstants.HeartbeatIntervalMs;
@@ -245,7 +251,18 @@ namespace UnityBridge
                 return;
 
             var statusMsg = Messages.CreateStatus(InstanceId, status, detail);
-            await _sendLock.WaitAsync(_cts?.Token ?? CancellationToken.None);
+            var token = _cts?.Token ?? CancellationToken.None;
+
+            // Bound the wait so a stuck send cannot block STATUS forever. On timeout
+            // we throw so callers (e.g. EditorStateCache) do not advance their
+            // "last sent" bookkeeping based on a message that never went out.
+            if (!await _sendLock.WaitAsync(StatusLockTimeoutMs, token))
+            {
+                var msg =
+                    $"SendStatusAsync lock timed out after {StatusLockTimeoutMs}ms (status={status})";
+                BridgeLog.Warn(msg);
+                throw new TimeoutException(msg);
+            }
             try
             {
                 await Framing.WriteFrameAsync(_stream, statusMsg);
@@ -378,9 +395,20 @@ namespace UnityBridge
         private async Task HandlePingAsync(JObject msg, CancellationToken cancellationToken)
         {
             var pingTs = Messages.ParsePing(msg);
-
             var pongMsg = Messages.CreatePong(pingTs);
-            await _sendLock.WaitAsync(cancellationToken);
+
+            // PONG is the most latency-critical send. Bound the lock wait so a stuck
+            // sender cannot starve PONG indefinitely. On timeout we drop this PONG
+            // rather than racing another writer (which would corrupt the framed stream);
+            // if PONGs keep failing the relay will close the connection on its own and
+            // we will reconnect via BridgeReloadHandler.
+            if (!await _sendLock.WaitAsync(PongLockTimeoutMs, cancellationToken))
+            {
+                BridgeLog.Warn(
+                    $"PONG send lock timed out after {PongLockTimeoutMs}ms — dropping this PONG");
+                return;
+            }
+
             try
             {
                 await Framing.WriteFrameAsync(_stream, pongMsg, cancellationToken);

--- a/UnityBridge/Editor/RelayClient.cs
+++ b/UnityBridge/Editor/RelayClient.cs
@@ -184,6 +184,11 @@ namespace UnityBridge
                     UnityVersion,
                     Capabilities);
 
+                // No ConfigureAwait(false) here: callers (BridgeManager.ConnectAsync,
+                // BridgeReloadHandler.ReconnectAsync) follow ConnectAsync with
+                // main-thread API calls (e.g. UnityEngine.Application.productName,
+                // BridgeLog -> EditorPrefs), so the continuation must stay on the
+                // Unity main thread.
                 await _sendLock.WaitAsync(cancellationToken);
                 try
                 {
@@ -256,7 +261,7 @@ namespace UnityBridge
             // Bound the wait so a stuck send cannot block STATUS forever. On timeout
             // we throw so callers (e.g. EditorStateCache) do not advance their
             // "last sent" bookkeeping based on a message that never went out.
-            if (!await _sendLock.WaitAsync(StatusLockTimeoutMs, token))
+            if (!await _sendLock.WaitAsync(StatusLockTimeoutMs, token).ConfigureAwait(false))
             {
                 var msg =
                     $"SendStatusAsync lock timed out after {StatusLockTimeoutMs}ms (status={status})";
@@ -265,7 +270,7 @@ namespace UnityBridge
             }
             try
             {
-                await Framing.WriteFrameAsync(_stream, statusMsg);
+                await Framing.WriteFrameAsync(_stream, statusMsg).ConfigureAwait(false);
             }
             finally
             {
@@ -323,10 +328,13 @@ namespace UnityBridge
 
             try
             {
-                await _sendLock.WaitAsync(_cts?.Token ?? CancellationToken.None);
+                // ConfigureAwait(false) keeps the lock-holding continuation off the
+                // Unity main thread so a non-focused editor cannot stall this send
+                // and starve PONG / STATUS waiting on _sendLock.
+                await _sendLock.WaitAsync(_cts?.Token ?? CancellationToken.None).ConfigureAwait(false);
                 try
                 {
-                    await Framing.WriteFrameAsync(_stream, message);
+                    await Framing.WriteFrameAsync(_stream, message).ConfigureAwait(false);
                 }
                 finally
                 {
@@ -352,8 +360,8 @@ namespace UnityBridge
             {
                 while (!cancellationToken.IsCancellationRequested && _client is { Connected: true })
                 {
-                    var msg = await Framing.ReadFrameAsync(_stream, cancellationToken);
-                    await HandleMessageAsync(msg, cancellationToken);
+                    var msg = await Framing.ReadFrameAsync(_stream, cancellationToken).ConfigureAwait(false);
+                    await HandleMessageAsync(msg, cancellationToken).ConfigureAwait(false);
                 }
             }
             catch (OperationCanceledException)
@@ -365,7 +373,7 @@ namespace UnityBridge
                 if (!cancellationToken.IsCancellationRequested)
                 {
                     BridgeLog.Error($"Receive loop error: {ex.Message}");
-                    await DisconnectInternalAsync();
+                    await DisconnectInternalAsync().ConfigureAwait(false);
                 }
             }
 
@@ -402,7 +410,7 @@ namespace UnityBridge
             // rather than racing another writer (which would corrupt the framed stream);
             // if PONGs keep failing the relay will close the connection on its own and
             // we will reconnect via BridgeReloadHandler.
-            if (!await _sendLock.WaitAsync(PongLockTimeoutMs, cancellationToken))
+            if (!await _sendLock.WaitAsync(PongLockTimeoutMs, cancellationToken).ConfigureAwait(false))
             {
                 BridgeLog.Warn(
                     $"PONG send lock timed out after {PongLockTimeoutMs}ms — dropping this PONG");
@@ -411,7 +419,7 @@ namespace UnityBridge
 
             try
             {
-                await Framing.WriteFrameAsync(_stream, pongMsg, cancellationToken);
+                await Framing.WriteFrameAsync(_stream, pongMsg, cancellationToken).ConfigureAwait(false);
             }
             finally
             {


### PR DESCRIPTION
## Summary

- 接続後 2 回目以降のコマンドがタイムアウトする問題 (#110) を修正
- 関連して RelayClient の送信経路を堅牢化し、PONG 飢餓によるハートビート切断 (#111) を防止

Closes #110
Closes #111

## 背景

`BridgeManager.OnCommandReceived` は `RelayClient.ReceiveLoopAsync` (Task.Run 配下のバックグラウンドスレッド) から発火するイベントで呼ばれていましたが、その中で `EditorApplication.update +=` と `EditorApplication.QueuePlayerLoopUpdate()` を呼んでいました。これらは Unity のメインスレッド専用 API で、バックグラウンドスレッドからの呼び出しは例外を出さずに無視されます。

結果として `ProcessCommandQueue` が `EditorApplication.update` に登録されず、コマンドキューに溜まったまま処理されない (タイムアウト) 状態になっていました。詳細は #110 を参照してください。

## 変更点

### #110 の修正
- `BridgeManager.ConnectAsync` (メインスレッド) で `EnsureUpdateRegistered()` を呼んで `EditorApplication.update` への登録を済ませる
- `BridgeManager.OnCommandReceived` はキュー投入のみに簡素化 (バックグラウンドスレッドからメインスレッド API を呼ばない)
- `BridgeManager.ConnectAsync` を try/catch で囲い、`Client.ConnectAsync()` 失敗時にイベント解除 / `UnregisterUpdate()` / `DisposeAsync` / `Client = null` までロールバック

### #111 の修正
- `RelayClient.HandlePingAsync`: `_sendLock.WaitAsync` に 3 秒タイムアウトを追加。タイムアウト時は並行書き込みでフレーム破損するリスクを避けて PONG をドロップする (relay 側で 3 回連続失敗すれば切断 → `BridgeReloadHandler` が再接続)
- `RelayClient.SendStatusAsync`: 5 秒タイムアウトを追加。送信失敗を呼び出し元 (`EditorStateCache` 等) に伝えるため `TimeoutException` を投げる
- `RelayClient.SendFrameAsync` / `HandlePingAsync` / `SendStatusAsync` / `ReceiveLoopAsync` 内の await に `ConfigureAwait(false)` を追加。これにより継続がスレッドプールで実行され、Unity Editor が非フォーカス時にメインスレッドが止まっても `_sendLock` が解放されるため PONG が飢餓しない (約 30 秒切断問題の解消)
- `RelayClient.ConnectAsync` 内の await は対象外。呼び出し元が `UnityEngine.Application.productName` 等のメインスレッド限定 API を継続で呼ぶため SyncContext を維持する必要があるため
- `BridgeLog.Enabled` を `[InitializeOnLoadMethod]` でメインスレッドキャッシュ + `Volatile` 共有に変更。送信経路で `ConfigureAwait(false)` を入れた結果プールスレッドからログを呼ぶケースで `EditorPrefs.GetBool` の "main thread only" 例外が出るのを防止
- `SendStatusAsync` / `SendFrameAsync` の `WriteFrameAsync` 呼び出しに `_cts.Token` を渡し、Disconnect 時に in-flight write がキャンセルされロックが解放されるようにする (per-send timeout の完全実装は #113 で別途対応)

### テスト
- `BridgeManagerThreadingTests.cs` を追加。`ConnectAsync` で `EditorApplication.update` ハンドラ登録が完了すること、`Disconnect → Connect` 再接続でも再登録されること、`Client.ConnectAsync()` 失敗時のロールバックが効くことを検証
- `BridgeManager.IsUpdateRegistered` を `internal` プロパティとして公開し、テストはリフレクションではなくこのプロパティ経由で検証

## 動作確認

### 接続・コマンド実行 (Unity 2022.3.62f3 / Unity 6000.0.72f1)
- [x] `u state` 連続実行が成功 (修正前は 1 回目のみ動作)
- [x] `u console get` 成功
- [x] `u scene hierarchy` 成功
- [x] Unity Editor 非フォーカスのまま 60 秒放置 → 切断なし、その後 `u state` 成功

### EditMode テスト (Unity 6000.2.6f2 / TestProject)
- [x] `u -i TestProject tests run edit -g BridgeManagerThreadingTests` で本 PR 追加分 3/3 パス
- [x] `u -i TestProject tests run edit` で全 164 件中 160 passed / 0 failed / 4 skipped (リグレッションなし)

```
$ u -i TestProject tests run edit -g BridgeManagerThreadingTests
running    False
complete   True
total      3
passed     3
failed     0
skipped    0
duration   0.9129664s
failedTests []

$ u -i TestProject tests run edit
running    False
complete   True
total      164
passed     160
failed     0
skipped    4
duration   9.9127353s
failedTests []
```

### レビュー
- [x] ローカル環境で codex によるレビュー実施、指摘事項なし
- [x] CodeRabbit のレビュー指摘 (critical 1 件 / nitpick 2 件) に対応

## コミット粒度

論理的に独立した単位で分割しています。

```
🐛 fix: バックグラウンドスレッドからの EditorApplication API 呼び出しを除去
🛡️ fix: ConnectAsync 失敗時の状態ロールバックを追加
✅ test: BridgeManager の update ハンドラ登録契約テストを追加
🛡️ improve: _sendLock 競合時のフェイルセーフタイムアウトを追加
🐛 fix: BridgeLog.Enabled をスレッドセーフキャッシュに変更
🐛 fix: 送信経路の継続をスレッドプールに逃がしてフォーカス依存を解消
✅ test: ConnectAsync 失敗時のロールバックテストを追加
🛡️ fix: WriteFrameAsync に CancellationToken を渡し Disconnect 時のハングを防止
♻️ refactor: BridgeManager に internal IsUpdateRegistered プロパティを追加
✅ refactor: _updateRegistered のリフレクション参照を IsUpdateRegistered 経由に置き換え
```

## Test plan

- [ ] Unity 2022.3.x で `u state` / `u console get` / `u tests run edit` が安定動作する
- [ ] Unity 6000.0.x / 6000.2.x で同上
- [ ] Unity Editor 非フォーカス時に長時間放置してもハートビート切断しない
- [ ] `uv run python -m pytest tests/` 全パス
- [ ] `u tests run edit -g BridgeManagerThreadingTests` が通る (TestProject)