### PR TITLE
📝 docs: AI向けにCLI helpメッセージの発見性を改善

### DIFF
--- a/unity_cli/cli/app.py
+++ b/unity_cli/cli/app.py
@@ -54,7 +54,24 @@ from unity_cli.config import UnityCLIConfig
 
 app = typer.Typer(
     name="unity-cli",
-    help="Unity CLI - Control Unity Editor via Relay Server",
+    help=(
+        "Unity CLI - Control a running Unity Editor from the shell or scripts.\n\n"
+        "Sends commands to the Unity Editor via a local Relay Server (TCP:6500).\n"
+        "Lets you: enter/exit play mode, refresh assets, read console logs, run tests,\n"
+        "create/modify GameObjects and Components, execute menu items (including custom\n"
+        "[MenuItem] entries), call arbitrary Unity static APIs, build players, inspect\n"
+        "scenes/UI Toolkit panels, capture screenshots, and more.\n\n"
+        "Quick start:\n"
+        "  u instances                            # List connected Unity Editors\n"
+        "  u -i <project> state                   # Show editor state for a specific project\n"
+        "  u refresh && u console get -l E        # Recompile then show errors+exceptions\n"
+        "  u console get -l W | head -50          # Tail warnings+ (pipe-friendly plain text)\n"
+        "  u console clear                        # Wipe the Console\n"
+        "  u menu exec 'Window/Package Manager'   # Run any menu item (built-in or custom)\n"
+        "  u api schema -t AssetDatabase          # Discover Unity static API methods\n"
+        "\n"
+        "All subcommands accept --help for detailed usage."
+    ),
     no_args_is_help=True,
     rich_markup_mode="rich",
 )
@@ -126,7 +143,25 @@ def main(
         ),
     ] = False,
 ) -> None:
-    """Unity CLI - Control Unity Editor via Relay Server."""
+    """Unity CLI - Control a running Unity Editor from the shell or scripts.
+
+    Sends commands to the Unity Editor via a local Relay Server (TCP:6500).
+    Lets you: enter/exit play mode, refresh assets, read console logs, run tests,
+    create/modify GameObjects and Components, execute menu items (including custom
+    [MenuItem] entries), call arbitrary Unity static APIs, build players, inspect
+    scenes/UI Toolkit panels, capture screenshots, and more.
+
+    Quick start:
+      u instances                            # List connected Unity Editors
+      u -i <project> state                   # Show editor state for a specific project
+      u refresh && u console get -l E        # Recompile then show errors+exceptions
+      u console get -l W | head -50          # Tail warnings+ (pipe-friendly plain text)
+      u console clear                        # Wipe the Console
+      u menu exec 'Window/Package Manager'   # Run any menu item (built-in or custom)
+      u api schema -t AssetDatabase          # Discover Unity static API methods
+
+    All subcommands accept --help for detailed usage.
+    """
     from unity_cli.client import UnityClient
 
     # Resolve output mode and configure consoles

--- a/unity_cli/cli/commands/api.py
+++ b/unity_cli/cli/commands/api.py
@@ -11,7 +11,15 @@ from unity_cli.cli.context import CLIContext
 from unity_cli.cli.helpers import _should_json, handle_cli_errors
 from unity_cli.cli.output import print_json, print_plain_table, print_success
 
-api_app = typer.Typer(help="Dynamic Unity API invocation")
+api_app = typer.Typer(
+    help=(
+        "Call any Unity static API method dynamically via reflection.\n\n"
+        "Bridges from the CLI to UnityEngine/UnityEditor static methods and properties\n"
+        "(e.g. AssetDatabase.Refresh, Application.unityVersion, EditorUtility.*).\n"
+        "Use 'api schema' to discover available methods and 'api call' to invoke them.\n"
+        "Instance methods are NOT supported — only public static members."
+    )
+)
 
 
 @api_app.command("call")
@@ -105,7 +113,17 @@ def api_schema(
         typer.Option("--json", help="Output as JSON"),
     ] = False,
 ) -> None:
-    """List available Unity static API methods."""
+    """List static API methods discoverable by 'api call'.
+
+    Returned entries include fully-qualified type, method name, return type,
+    and parameter signature. Combine filters to narrow the search.
+
+    Examples:
+        u api schema -t AssetDatabase               # All methods on one type
+        u api schema -n UnityEditor                  # Everything under a namespace
+        u api schema -m Refresh                      # Any method named Refresh
+        u api schema --offline --version 2022.3      # Browse cached schema offline
+    """
     context: CLIContext = ctx.obj
     result = context.client.dynamic_api.schema(
         namespace=namespace,

--- a/unity_cli/cli/commands/asset.py
+++ b/unity_cli/cli/commands/asset.py
@@ -10,7 +10,17 @@ from unity_cli.cli.context import CLIContext
 from unity_cli.cli.helpers import _exit_usage, _should_json, handle_cli_errors
 from unity_cli.cli.output import is_no_color, print_json, print_key_value, print_line, print_plain_table, print_success
 
-asset_app = typer.Typer(help="Asset commands (Prefab, ScriptableObject)")
+asset_app = typer.Typer(
+    help=(
+        "Create and inspect project assets (Prefabs, ScriptableObjects) and explore\n"
+        "dependency graphs via AssetDatabase.\n\n"
+        "Commands:\n"
+        "  prefab / scriptable-object  Create new asset files from scene objects or types\n"
+        "  info                        Show asset GUID, type, importer info\n"
+        "  deps                        What an asset depends on (textures, meshes, ...)\n"
+        "  refs                        What depends on this asset (reverse lookup)"
+    )
+)
 
 
 @asset_app.command("prefab")
@@ -21,7 +31,12 @@ def asset_prefab(
     source: Annotated[str | None, typer.Option("--source", "-s", help="Source GameObject name")] = None,
     source_id: Annotated[int | None, typer.Option("--source-id", help="Source GameObject instance ID")] = None,
 ) -> None:
-    """Create a Prefab from a GameObject."""
+    """Save a scene GameObject (and its children) as a Prefab asset.
+
+    Examples:
+        u asset prefab -s Player -p Assets/Prefabs/Player.prefab
+        u asset prefab --source-id 12345 -p Assets/Prefabs/Enemy.prefab
+    """
     context: CLIContext = ctx.obj
 
     if not source and source_id is None:
@@ -42,7 +57,14 @@ def asset_scriptable_object(
     type_name: Annotated[str, typer.Option("--type", "-T", help="ScriptableObject type name")],
     path: Annotated[str, typer.Option("--path", "-p", help="Output path (e.g., Assets/Data/My.asset)")],
 ) -> None:
-    """Create a ScriptableObject asset."""
+    """Instantiate a ScriptableObject-derived type as a new .asset file.
+
+    --type takes the concrete class name (short or fully-qualified). The type
+    must derive from UnityEngine.ScriptableObject and be reachable at runtime.
+
+    Example:
+        u asset scriptable-object -T GameConfig -p Assets/Data/GameConfig.asset
+    """
     context: CLIContext = ctx.obj
     result = context.client.asset.create_scriptable_object(
         type_name=type_name,
@@ -61,7 +83,11 @@ def asset_info(
         typer.Option("--json", help="Output as JSON"),
     ] = False,
 ) -> None:
-    """Get asset information."""
+    """Show AssetDatabase metadata for a project asset (GUID, type, importer).
+
+    Example:
+        u asset info Assets/Prefabs/Player.prefab
+    """
     context: CLIContext = ctx.obj
     result = context.client.asset.info(path=path)
     if _should_json(context, json_flag):
@@ -84,7 +110,14 @@ def asset_deps(
         typer.Option("--json", help="Output as JSON"),
     ] = False,
 ) -> None:
-    """Get asset dependencies (what this asset depends on)."""
+    """List assets that the given asset references (forward dependency graph).
+
+    Recursive by default (-R for direct deps only).
+
+    Example:
+        u asset deps Assets/Scenes/Main.unity
+        u asset deps Assets/Prefabs/Player.prefab -R
+    """
     context: CLIContext = ctx.obj
     result = context.client.asset.deps(path=path, recursive=recursive)
     if _should_json(context, json_flag):
@@ -115,7 +148,14 @@ def asset_refs(
         typer.Option("--json", help="Output as JSON"),
     ] = False,
 ) -> None:
-    """Get asset referencers (what depends on this asset)."""
+    """Reverse lookup: find every asset that references the given asset.
+
+    Useful before deleting/renaming to see where a texture, material, or
+    ScriptableObject is wired in.
+
+    Example:
+        u asset refs Assets/Materials/Wood.mat
+    """
     context: CLIContext = ctx.obj
     result = context.client.asset.refs(path=path)
     if _should_json(context, json_flag):

--- a/unity_cli/cli/commands/build.py
+++ b/unity_cli/cli/commands/build.py
@@ -21,7 +21,13 @@ from unity_cli.cli.output import (
 )
 from unity_cli.exceptions import UnityCLIError
 
-build_app = typer.Typer(help="Build pipeline commands")
+build_app = typer.Typer(
+    help=(
+        "Drive Unity's BuildPipeline from the CLI (standalone, mobile, WebGL, ...).\n\n"
+        "Inspect the project's current Build Settings, list the scenes queued for\n"
+        "build, and kick off a player build for any BuildTarget the project supports."
+    )
+)
 
 
 @build_app.command("settings")
@@ -32,7 +38,7 @@ def build_settings(
         typer.Option("--json", help="Output as JSON"),
     ] = False,
 ) -> None:
-    """Show current build settings."""
+    """Print the current Build Settings (target, product info, scripting backend, scenes)."""
     context: CLIContext = ctx.obj
     try:
         result = context.client.build.settings()
@@ -90,7 +96,20 @@ def build_run(
         typer.Option("--json", help="Output as JSON"),
     ] = False,
 ) -> None:
-    """Run a build."""
+    """Execute a player build (BuildPipeline.BuildPlayer) and report results.
+
+    Defaults use the project's current Build Settings. Override --target for
+    a different platform or --scene to pick a one-off scene set. Exits non-zero
+    on build failure.
+
+    --target accepts Unity BuildTarget names, e.g.:
+      StandaloneWindows64, StandaloneOSX, StandaloneLinux64, Android, iOS, WebGL.
+
+    Examples:
+        u build run                                          # Use current settings
+        u build run -t StandaloneOSX -o Build/Mac/App.app
+        u build run -t Android -o Build/app.apk -s Assets/Scenes/Main.unity
+    """
     context: CLIContext = ctx.obj
     try:
         result = context.client.build.build(
@@ -138,7 +157,7 @@ def build_scenes(
         typer.Option("--json", help="Output as JSON"),
     ] = False,
 ) -> None:
-    """List build scenes."""
+    """List the scenes registered in Build Settings (with enabled flag and GUID)."""
     context: CLIContext = ctx.obj
     try:
         result = context.client.build.scenes()

--- a/unity_cli/cli/commands/component.py
+++ b/unity_cli/cli/commands/component.py
@@ -10,7 +10,15 @@ from unity_cli.cli.context import CLIContext
 from unity_cli.cli.helpers import _exit_usage, _parse_cli_value, _should_json, handle_cli_errors
 from unity_cli.cli.output import print_components_table, print_json, print_key_value, print_success
 
-component_app = typer.Typer(help="Component commands")
+component_app = typer.Typer(
+    help=(
+        "List, inspect, add, modify, and remove Components on GameObjects.\n\n"
+        "The --type/-T option accepts a Component type name (short like 'Rigidbody',\n"
+        "'Camera', 'Transform', or fully-qualified like 'UnityEngine.Rigidbody').\n"
+        "User MonoBehaviour types work too if they are reachable by name. Targets\n"
+        "are chosen with --target <name> or --target-id <instance-id>."
+    )
+)
 
 
 @component_app.command("list")
@@ -24,7 +32,11 @@ def component_list(
         typer.Option("--json", help="Output as JSON"),
     ] = False,
 ) -> None:
-    """List components on a GameObject."""
+    """Enumerate every Component attached to a GameObject.
+
+    Example:
+        u component list -t Player
+    """
     context: CLIContext = ctx.obj
 
     if not target and target_id is None:
@@ -49,7 +61,11 @@ def component_inspect(
         typer.Option("--json", help="Output as JSON"),
     ] = False,
 ) -> None:
-    """Inspect component properties."""
+    """Dump all serialized property values of a Component on a GameObject.
+
+    Example:
+        u component inspect -t "Main Camera" -T Camera
+    """
     context: CLIContext = ctx.obj
 
     if not target and target_id is None:
@@ -74,7 +90,13 @@ def component_add(
     target: Annotated[str | None, typer.Option("--target", "-t", help="Target GameObject name")] = None,
     target_id: Annotated[int | None, typer.Option("--target-id", help="Target GameObject ID")] = None,
 ) -> None:
-    """Add a component to a GameObject."""
+    """Attach a new Component to a GameObject.
+
+    Examples:
+        u component add -t Player -T Rigidbody
+        u component add -t Enemy  -T UnityEngine.BoxCollider
+        u component add -t Enemy  -T MyNamespace.HealthController   # custom MonoBehaviour
+    """
     context: CLIContext = ctx.obj
 
     if not target and target_id is None:
@@ -136,7 +158,11 @@ def component_remove(
     target: Annotated[str | None, typer.Option("--target", "-t", help="Target GameObject name")] = None,
     target_id: Annotated[int | None, typer.Option("--target-id", help="Target GameObject ID")] = None,
 ) -> None:
-    """Remove a component from a GameObject."""
+    """Detach/destroy a Component from a GameObject.
+
+    Example:
+        u component remove -t Enemy -T BoxCollider
+    """
     context: CLIContext = ctx.obj
 
     if not target and target_id is None:

--- a/unity_cli/cli/commands/config.py
+++ b/unity_cli/cli/commands/config.py
@@ -13,7 +13,14 @@ from unity_cli.cli.helpers import _should_json
 from unity_cli.cli.output import print_error, print_json, print_line, print_success
 from unity_cli.config import CONFIG_FILE_NAME, UnityCLIConfig
 
-config_app = typer.Typer(help="Configuration commands")
+config_app = typer.Typer(
+    help=(
+        "Inspect or generate the unity-cli config file (.unity-cli.toml).\n\n"
+        "Stores default relay host/port, timeout, and the preferred Unity instance\n"
+        "so you don't need to repeat --relay-* or -i on every invocation. Looked up\n"
+        "from the current directory upward, similar to .editorconfig."
+    )
+)
 
 
 @config_app.command("show")
@@ -24,7 +31,7 @@ def config_show(
         typer.Option("--json", help="Output as JSON"),
     ] = False,
 ) -> None:
-    """Show current configuration."""
+    """Print the resolved config (from file + env vars + CLI flags) and its source path."""
     context: CLIContext = ctx.obj
     config_file = UnityCLIConfig._find_config_file()
 
@@ -59,7 +66,10 @@ def config_init(
         typer.Option("--force", "-f", help="Overwrite existing config"),
     ] = False,
 ) -> None:
-    """Generate default .unity-cli.toml configuration file."""
+    """Write a default .unity-cli.toml into the current directory (edit to taste).
+
+    Use --output to pick a different path, --force to overwrite an existing file.
+    """
     output_path = output or Path(CONFIG_FILE_NAME)
 
     if output_path.exists() and not force:

--- a/unity_cli/cli/commands/console.py
+++ b/unity_cli/cli/commands/console.py
@@ -11,7 +11,15 @@ from unity_cli.cli.helpers import _handle_error, _should_json
 from unity_cli.cli.output import print_json, print_line, print_success, print_warning
 from unity_cli.exceptions import UnityCLIError
 
-console_app = typer.Typer(help="Console log commands")
+console_app = typer.Typer(
+    help=(
+        "Read and clear the Unity Editor Console log.\n\n"
+        "Mirrors entries produced by Debug.Log/LogWarning/LogError/LogException, plus\n"
+        "compiler errors. Use 'get' to retrieve logs with adb-logcat-style level\n"
+        "filtering (and pipe to head/grep for narrowing), and 'clear' to wipe them.\n"
+        "Tip: combine with 'u refresh' to surface compilation errors from the shell."
+    )
+)
 
 
 def _parse_level(level: str) -> list[str]:
@@ -151,7 +159,7 @@ def _print_console_entries(entries: list[dict[str, Any]], include_stacktrace: bo
 
 @console_app.command("clear")
 def console_clear(ctx: typer.Context) -> None:
-    """Clear console logs."""
+    """Wipe the Unity Console (same as clicking 'Clear' in the Console window)."""
     context: CLIContext = ctx.obj
     try:
         context.client.console.clear()

--- a/unity_cli/cli/commands/editor_control.py
+++ b/unity_cli/cli/commands/editor_control.py
@@ -37,7 +37,12 @@ def register(app: typer.Typer) -> None:
             typer.Option("--json", help="Output as JSON"),
         ] = False,
     ) -> None:
-        """List connected Unity instances."""
+        """List Unity Editor instances currently registered with the Relay Server.
+
+        Each row shows the project path/name and its instance ID. Use the name
+        or path prefix with --instance/-i on any command to target a specific
+        editor when more than one is open.
+        """
         context: CLIContext = ctx.obj
         try:
             result = context.client.list_instances()
@@ -57,7 +62,10 @@ def register(app: typer.Typer) -> None:
             typer.Option("--json", help="Output as JSON"),
         ] = False,
     ) -> None:
-        """Get editor state."""
+        """Return current editor state: play mode, pause, compilation, active scene.
+
+        Useful as a readiness probe before scripting other commands.
+        """
         context: CLIContext = ctx.obj
         try:
             result = context.client.editor.get_state()
@@ -70,7 +78,7 @@ def register(app: typer.Typer) -> None:
 
     @app.command()
     def play(ctx: typer.Context) -> None:
-        """Enter play mode."""
+        """Enter Play Mode (equivalent to pressing the Play button in the editor)."""
         context: CLIContext = ctx.obj
         try:
             context.client.editor.play()
@@ -80,7 +88,7 @@ def register(app: typer.Typer) -> None:
 
     @app.command()
     def stop(ctx: typer.Context) -> None:
-        """Exit play mode."""
+        """Exit Play Mode and return to Edit Mode."""
         context: CLIContext = ctx.obj
         try:
             context.client.editor.stop()
@@ -90,7 +98,7 @@ def register(app: typer.Typer) -> None:
 
     @app.command()
     def pause(ctx: typer.Context) -> None:
-        """Toggle pause."""
+        """Toggle Play Mode pause (has no effect when not in Play Mode)."""
         context: CLIContext = ctx.obj
         try:
             context.client.editor.pause()
@@ -100,7 +108,11 @@ def register(app: typer.Typer) -> None:
 
     @app.command()
     def refresh(ctx: typer.Context) -> None:
-        """Refresh asset database (trigger recompilation)."""
+        """Run AssetDatabase.Refresh — reimport changed assets and recompile scripts.
+
+        Equivalent to 'Assets > Refresh' / Ctrl+R in the editor. Use after editing
+        C# files from outside Unity to force a compile.
+        """
         context: CLIContext = ctx.obj
         try:
             context.client.editor.refresh()

--- a/unity_cli/cli/commands/editor_hub.py
+++ b/unity_cli/cli/commands/editor_hub.py
@@ -10,7 +10,14 @@ from unity_cli.cli.context import CLIContext
 from unity_cli.cli.helpers import _handle_error, _should_json
 from unity_cli.cli.output import _print_plain_table, get_console, is_no_color, print_json, print_line, print_success
 
-editor_app = typer.Typer(help="Unity Editor management (via Hub)")
+editor_app = typer.Typer(
+    help=(
+        "Manage Unity Editor installations via Unity Hub CLI (no Relay required).\n\n"
+        "Lists locally installed editors (by scanning Hub's config + common install\n"
+        "paths) and invokes Hub's CLI to install new versions with optional modules.\n"
+        "Pairs with 'u open <project>' which auto-picks the right editor for a project."
+    )
+)
 
 
 @editor_app.command("list")
@@ -21,7 +28,10 @@ def editor_list(
         typer.Option("--json", help="Output as JSON"),
     ] = False,
 ) -> None:
-    """List installed Unity editors."""
+    """List every Unity Editor installed on this machine (version + path).
+
+    Scans Unity Hub's config and standard install locations.
+    """
     context: CLIContext = ctx.obj
     from unity_cli.hub.paths import get_installed_editors
 
@@ -61,9 +71,16 @@ def editor_install(
         typer.Option("--changeset", "-c", help="Changeset for non-release versions"),
     ] = None,
 ) -> None:
-    """Install Unity Editor via Hub CLI.
+    """Install a Unity Editor version through Unity Hub's CLI.
 
-    Example: unity-cli editor install 2022.3.10f1 --modules android ios
+    VERSION accepts release tags like '2022.3.10f1', '6000.0.23f1', or beta/alpha
+    tags paired with --changeset. --modules takes Unity platform/module IDs
+    (android, ios, webgl, mac-il2cpp, linux-il2cpp, windows-il2cpp, ...).
+
+    Examples:
+        u editor install 2022.3.10f1
+        u editor install 2022.3.10f1 -m android -m ios
+        u editor install 6000.0.1a14 --changeset abcdef123456
     """
     from unity_cli.exceptions import HubError
     from unity_cli.hub.hub_cli import HubCLI

--- a/unity_cli/cli/commands/gameobject.py
+++ b/unity_cli/cli/commands/gameobject.py
@@ -11,7 +11,14 @@ from unity_cli.cli.context import CLIContext
 from unity_cli.cli.helpers import _exit_usage, _should_json, handle_cli_errors
 from unity_cli.cli.output import is_no_color, print_json, print_line, print_plain_table, print_success
 
-gameobject_app = typer.Typer(help="GameObject commands")
+gameobject_app = typer.Typer(
+    help=(
+        "Create, find, modify, (de)activate, and delete GameObjects in the active scene.\n\n"
+        "Targets can be specified by name (first match) or instance ID. Transforms are\n"
+        "edited via --position / --rotation / --scale. Combine with the 'component'\n"
+        "commands to attach or tweak components on the resulting objects."
+    )
+)
 
 
 @gameobject_app.command("find")
@@ -25,7 +32,15 @@ def gameobject_find(
         typer.Option("--json", help="Output as JSON"),
     ] = False,
 ) -> None:
-    """Find GameObjects by name or ID."""
+    """Locate GameObjects in the active scene by name or instance ID.
+
+    Returns all matching objects with their instance IDs — use the ID for
+    precise follow-up commands when multiple share a name.
+
+    Examples:
+        u gameobject find -n Player
+        u gameobject find --id 12345
+    """
     context: CLIContext = ctx.obj
 
     if not name and id is None:
@@ -54,7 +69,11 @@ def gameobject_create(
     name: Annotated[str, typer.Option("--name", "-n", help="GameObject name")],
     primitive: Annotated[
         str | None,
-        typer.Option("--primitive", "-p", help="Primitive type (Cube, Sphere, etc.)"),
+        typer.Option(
+            "--primitive",
+            "-p",
+            help="Primitive type: Cube, Sphere, Capsule, Cylinder, Plane, Quad (omit for empty GameObject)",
+        ),
     ] = None,
     position: Annotated[
         tuple[float, float, float] | None,
@@ -69,7 +88,18 @@ def gameobject_create(
         typer.Option("--scale", help="Scale (X Y Z)"),
     ] = None,
 ) -> None:
-    """Create a new GameObject."""
+    """Create a GameObject (empty or primitive) in the active scene.
+
+    Omit --primitive for an empty GameObject. Pass one of the primitive types
+    (Cube/Sphere/Capsule/Cylinder/Plane/Quad) to spawn a preconfigured mesh
+    with collider. Transform options set the initial pose; each takes three
+    floats (X Y Z).
+
+    Examples:
+        u gameobject create -n Empty
+        u gameobject create -n Wall -p Cube --position 0 0 5 --scale 10 2 1
+        u gameobject create -n Floor -p Plane --rotation 0 0 0
+    """
     context: CLIContext = ctx.obj
     result = context.client.gameobject.create(
         name=name,
@@ -100,7 +130,15 @@ def gameobject_modify(
         typer.Option("--scale", help="Scale (X Y Z)"),
     ] = None,
 ) -> None:
-    """Modify GameObject transform."""
+    """Update a GameObject's position, rotation, and/or scale.
+
+    Only the Transform options you pass are modified; the rest stay unchanged.
+    Rotation is Euler angles in degrees.
+
+    Examples:
+        u gameobject modify -n Player --position 1 0 -3
+        u gameobject modify --id 12345 --rotation 0 90 0 --scale 2 2 2
+    """
     context: CLIContext = ctx.obj
 
     if not name and id is None:
@@ -127,7 +165,14 @@ def gameobject_active(
         typer.Option("--active/--no-active", help="Set active (true) or inactive (false)"),
     ] = True,
 ) -> None:
-    """Set GameObject active state."""
+    """Enable or disable a GameObject (equivalent to the Inspector's top-left toggle).
+
+    Use --no-active to disable. The default --active enables the object.
+
+    Examples:
+        u gameobject active -n HUD --no-active
+        u gameobject active --id 12345 --active
+    """
     context: CLIContext = ctx.obj
 
     if not name and id is None:
@@ -148,7 +193,12 @@ def gameobject_delete(
     name: Annotated[str | None, typer.Option("--name", "-n", help="GameObject name")] = None,
     id: Annotated[int | None, typer.Option("--id", help="Instance ID")] = None,
 ) -> None:
-    """Delete a GameObject."""
+    """Destroy a GameObject from the active scene.
+
+    Examples:
+        u gameobject delete -n TempSpawn
+        u gameobject delete --id 12345
+    """
     context: CLIContext = ctx.obj
 
     if not name and id is None:

--- a/unity_cli/cli/commands/menu.py
+++ b/unity_cli/cli/commands/menu.py
@@ -13,15 +13,37 @@ from unity_cli.cli.helpers import _handle_error, _should_json
 from unity_cli.cli.output import is_no_color, print_error, print_json, print_line, print_plain_item, print_success
 from unity_cli.exceptions import UnityCLIError
 
-menu_app = typer.Typer(help="Menu item commands")
+menu_app = typer.Typer(
+    help=(
+        "Invoke Unity menu items and [ContextMenu] methods.\n\n"
+        "Covers any MenuItem registered with Unity's menu bar — Unity's built-in menus\n"
+        "(Edit/Play, Assets/Refresh, Window/...) AND custom editor tools you or a\n"
+        'package register via [MenuItem("Tools/MyTool")]. This is the go-to way to\n'
+        "trigger editor workflows that have no dedicated CLI command."
+    )
+)
 
 
 @menu_app.command("exec")
 def menu_exec(
     ctx: typer.Context,
-    path: Annotated[str, typer.Argument(help="Menu item path (e.g., 'Edit/Play')")],
+    path: Annotated[str, typer.Argument(help="Menu item path (e.g., 'Edit/Play', 'Tools/MyCustomAction')")],
 ) -> None:
-    """Execute a Unity menu item."""
+    """Execute any Unity menu item by its menu-bar path.
+
+    Works with:
+      - Built-in menus: 'Edit/Play', 'File/Save', 'Assets/Refresh'
+      - Package menus:  'Window/Package Manager', 'Window/Analysis/Profiler'
+      - Custom tools:   any [MenuItem("Path/To/Action")] defined in your project
+
+    Use 'u menu list' (optionally with --filter) to discover available menu paths.
+
+    Examples:
+        u menu exec 'Edit/Play'
+        u menu exec 'Assets/Refresh'
+        u menu exec 'Window/Rendering/Lighting'
+        u menu exec 'Tools/RegenerateData'          # custom [MenuItem]
+    """
     context: CLIContext = ctx.obj
     try:
         result = context.client.menu.execute(path)
@@ -50,7 +72,15 @@ def menu_list(
         typer.Option("--json", help="Output as JSON"),
     ] = False,
 ) -> None:
-    """List available menu items."""
+    """List Unity menu-bar entries (built-in + custom [MenuItem]).
+
+    Useful for discovering which paths 'u menu exec' can invoke.
+
+    Examples:
+        u menu list                        # All menu items
+        u menu list -f Tools               # Items containing 'Tools'
+        u menu list -f "Window/Analysis"   # Narrow to a submenu
+    """
     context: CLIContext = ctx.obj
     try:
         result = context.client.menu.list(filter_text=filter_text, limit=limit)
@@ -80,7 +110,17 @@ def menu_context(
         typer.Option("--target", "-t", help="Target object path (hierarchy or asset)"),
     ] = None,
 ) -> None:
-    """Execute a ContextMenu method on target object."""
+    """Invoke a [ContextMenu] method on a GameObject, Component, or Asset.
+
+    Targets methods decorated with [ContextMenu("MethodName")] in MonoBehaviours
+    or ScriptableObjects — equivalent to right-clicking the component header and
+    selecting the entry. If --target is omitted, the current Selection is used.
+
+    Examples:
+        u menu context Reset                                 # On current selection
+        u menu context Bake -t "Assets/Data/LightConfig.asset"
+        u menu context Regenerate -t "Player"                # Hierarchy name
+    """
     context: CLIContext = ctx.obj
     try:
         result = context.client.menu.context(method=method, target=target)

--- a/unity_cli/cli/commands/package.py
+++ b/unity_cli/cli/commands/package.py
@@ -11,7 +11,14 @@ from unity_cli.cli.helpers import _handle_error, _should_json
 from unity_cli.cli.output import _print_plain_table, get_console, is_no_color, print_json, print_success
 from unity_cli.exceptions import UnityCLIError
 
-package_app = typer.Typer(help="Package Manager commands (via Relay)")
+package_app = typer.Typer(
+    help=(
+        "Query and manage UPM packages in the open Unity project (Package Manager).\n\n"
+        "Runs through UnityEditor.PackageManager.Client inside the Editor, so changes\n"
+        "touch Packages/manifest.json and trigger a domain reload — the CLI waits for\n"
+        "that reload to complete before returning."
+    )
+)
 
 
 @package_app.command("list")
@@ -22,7 +29,7 @@ def package_list(
         typer.Option("--json", help="Output as JSON"),
     ] = False,
 ) -> None:
-    """List installed packages."""
+    """List packages currently installed (registry, git, local, built-in)."""
     context: CLIContext = ctx.obj
     try:
         result = context.client.package.list()
@@ -60,9 +67,25 @@ def package_list(
 @package_app.command("add")
 def package_add(
     ctx: typer.Context,
-    name: Annotated[str, typer.Argument(help="Package ID (e.g., com.unity.textmeshpro@3.0.6)")],
+    name: Annotated[
+        str,
+        typer.Argument(
+            help=(
+                "Package identifier. Accepts the same forms as UPM: "
+                "'com.unity.textmeshpro@3.0.6' (registry), "
+                "'https://github.com/org/repo.git' (git), "
+                "'file:../LocalPackage' (local path)."
+            )
+        ),
+    ],
 ) -> None:
-    """Add a package."""
+    """Install a package via the Package Manager (same as Window > Package Manager > Add).
+
+    Examples:
+        u package add com.unity.textmeshpro@3.0.6
+        u package add https://github.com/cysharp/UniTask.git?path=src/UniTask/Assets/Plugins/UniTask
+        u package add file:../Shared/MyLocalPackage
+    """
     context: CLIContext = ctx.obj
     try:
         result = context.client.package.add(name)
@@ -76,7 +99,11 @@ def package_remove(
     ctx: typer.Context,
     name: Annotated[str, typer.Argument(help="Package name (e.g., com.unity.textmeshpro)")],
 ) -> None:
-    """Remove a package."""
+    """Uninstall a package (removes the entry from Packages/manifest.json).
+
+    Example:
+        u package remove com.unity.textmeshpro
+    """
     context: CLIContext = ctx.obj
     try:
         result = context.client.package.remove(name)

--- a/unity_cli/cli/commands/profiler.py
+++ b/unity_cli/cli/commands/profiler.py
@@ -19,7 +19,15 @@ from unity_cli.cli.output import (
 )
 from unity_cli.exceptions import UnityCLIError
 
-profiler_app = typer.Typer(help="Profiler commands")
+profiler_app = typer.Typer(
+    help=(
+        "Drive Unity's Profiler and read frame metrics (FPS, CPU/GPU ms, draw calls,\n"
+        "GC allocs, etc.).\n\n"
+        "Typical flow: 'start' → exercise your app → 'frames -c 60' to summarize the\n"
+        "last N frames, or 'snapshot' for the current frame only. 'stop' pauses data\n"
+        "collection. Works in both EditMode and PlayMode."
+    )
+)
 
 
 @profiler_app.command("status")
@@ -30,7 +38,7 @@ def profiler_status(
         typer.Option("--json", help="Output as JSON"),
     ] = False,
 ) -> None:
-    """Get profiler status."""
+    """Show whether profiling is currently enabled and the captured frame range."""
     context: CLIContext = ctx.obj
     try:
         result = context.client.profiler.status()
@@ -47,7 +55,7 @@ def profiler_status(
 
 @profiler_app.command("start")
 def profiler_start(ctx: typer.Context) -> None:
-    """Start profiling."""
+    """Enable Unity's Profiler (starts recording frame data into Unity's ring buffer)."""
     context: CLIContext = ctx.obj
     try:
         result = context.client.profiler.start()
@@ -61,7 +69,7 @@ def profiler_start(ctx: typer.Context) -> None:
 
 @profiler_app.command("stop")
 def profiler_stop(ctx: typer.Context) -> None:
-    """Stop profiling."""
+    """Pause the Profiler. Previously captured frames stay available for 'frames'/'snapshot'."""
     context: CLIContext = ctx.obj
     try:
         result = context.client.profiler.stop()
@@ -78,7 +86,7 @@ def profiler_snapshot(
         typer.Option("--json", help="Output as JSON"),
     ] = False,
 ) -> None:
-    """Get current frame profiler data."""
+    """Return metrics for the latest profiled frame (FPS, CPU/GPU ms, draw calls, GC allocs)."""
     context: CLIContext = ctx.obj
     try:
         result = context.client.profiler.snapshot()
@@ -128,7 +136,11 @@ def profiler_frames(
         typer.Option("--json", help="Output as JSON"),
     ] = False,
 ) -> None:
-    """Get recent N frames summary."""
+    """Return a table of the most recent N profiled frames with per-frame metrics.
+
+    Example:
+        u profiler frames -c 30
+    """
     context: CLIContext = ctx.obj
     try:
         result = context.client.profiler.frames(count=count)

--- a/unity_cli/cli/commands/project.py
+++ b/unity_cli/cli/commands/project.py
@@ -12,7 +12,15 @@ from unity_cli.cli.exit_codes import ExitCode
 from unity_cli.cli.helpers import _handle_error, _should_json
 from unity_cli.cli.output import _print_plain_table, get_console, is_no_color, print_error, print_json, print_line
 
-project_app = typer.Typer(help="Project information (file-based, no Relay required)")
+project_app = typer.Typer(
+    help=(
+        "Read project metadata directly from files on disk (no running Editor needed).\n\n"
+        "Parses ProjectSettings/*.asset, Packages/manifest.json, and .asmdef files to\n"
+        "surface Unity version, product info, build scenes, packages, tags/layers,\n"
+        "quality settings, and Assembly Definitions. Safe to run on closed projects\n"
+        "or in CI without a Unity license."
+    )
+)
 
 
 @project_app.command("info")

--- a/unity_cli/cli/commands/recorder.py
+++ b/unity_cli/cli/commands/recorder.py
@@ -20,7 +20,15 @@ from unity_cli.cli.output import (
 )
 from unity_cli.exceptions import UnityCLIError
 
-recorder_app = typer.Typer(help="Frame recording commands")
+recorder_app = typer.Typer(
+    help=(
+        "Continuously capture frames from a Camera to disk (multi-frame recording).\n\n"
+        "Unlike 'u screenshot' (one-shot or fixed burst), this streams PNG/JPG frames\n"
+        "at a target FPS into an output directory until 'stop' is called. Useful for\n"
+        "gameplay capture, time-lapse, or automated visual regression runs.\n"
+        "Use 'u screenshot' for single captures or fixed-length bursts instead."
+    )
+)
 
 
 @recorder_app.command("start")
@@ -59,7 +67,17 @@ def recorder_start(
         typer.Option("--json", "-j", help="Output as JSON"),
     ] = False,
 ) -> None:
-    """Start recording frames from camera."""
+    """Begin streaming Camera frames to disk until 'u recorder stop' is called.
+
+    If --output is omitted, frames go to a timestamped folder under the project's
+    temp directory (shown in the success output). Use 'u recorder status' to check
+    progress, and 'u recorder stop' to finish and get the summary.
+
+    Examples:
+        u recorder start                                    # Main Camera, jpg, 30fps
+        u recorder start --fps 60 -f png -o ./capture
+        u recorder start -c "UI Camera" -W 1280 -H 720
+    """
     context: CLIContext = ctx.obj
 
     if format not in ("png", "jpg"):
@@ -98,7 +116,7 @@ def recorder_stop(
         typer.Option("--json", "-j", help="Output as JSON"),
     ] = False,
 ) -> None:
-    """Stop recording and get results."""
+    """End an active recording and report total frames, duration, FPS, and output dir."""
     context: CLIContext = ctx.obj
 
     try:
@@ -127,7 +145,7 @@ def recorder_status(
         typer.Option("--json", "-j", help="Output as JSON"),
     ] = False,
 ) -> None:
-    """Check recording status."""
+    """Show whether recording is active and the current frame count / elapsed time / pending writes."""
     context: CLIContext = ctx.obj
 
     try:

--- a/unity_cli/cli/commands/scene.py
+++ b/unity_cli/cli/commands/scene.py
@@ -10,7 +10,13 @@ from unity_cli.cli.context import CLIContext
 from unity_cli.cli.helpers import _exit_usage, _should_json, handle_cli_errors
 from unity_cli.cli.output import print_hierarchy_table, print_json, print_key_value, print_success
 
-scene_app = typer.Typer(help="Scene management commands")
+scene_app = typer.Typer(
+    help=(
+        "Inspect and manage the open Unity scene(s).\n\n"
+        "Get the active scene, walk the GameObject hierarchy (paginated), load a scene\n"
+        "by path/name (single or additive), and save the current scene to an asset path."
+    )
+)
 
 
 @scene_app.command("active")
@@ -22,7 +28,7 @@ def scene_active(
         typer.Option("--json", help="Output as JSON"),
     ] = False,
 ) -> None:
-    """Get active scene info."""
+    """Show the currently active scene (name, path, isDirty, build index)."""
     context: CLIContext = ctx.obj
     result = context.client.scene.get_active()
     if _should_json(context, json_flag):
@@ -43,7 +49,16 @@ def scene_hierarchy(
         typer.Option("--json", help="Output as JSON"),
     ] = False,
 ) -> None:
-    """Get scene hierarchy."""
+    """Dump the active scene's GameObject hierarchy as a tree.
+
+    Results are paginated (--page-size + --cursor) so large scenes stay responsive.
+    Use --depth to limit how deep to recurse (1 = root objects only).
+
+    Examples:
+        u scene hierarchy                # Root GameObjects
+        u scene hierarchy -d 3           # Down to depth 3
+        u scene hierarchy --json         # Machine-readable output
+    """
     context: CLIContext = ctx.obj
     result = context.client.scene.get_hierarchy(
         depth=depth,
@@ -64,7 +79,17 @@ def scene_load(
     name: Annotated[str | None, typer.Option("--name", "-n", help="Scene name")] = None,
     additive: Annotated[bool, typer.Option("--additive", "-a", help="Load additively")] = False,
 ) -> None:
-    """Load a scene."""
+    """Open a scene in the editor (single or additive).
+
+    Identify the scene by asset path (--path) or by scene name (--name).
+    Paths resolve relative to the project (Assets/...). Unsaved changes in the
+    current scene are discarded unless --additive is set.
+
+    Examples:
+        u scene load -p Assets/Scenes/Main.unity
+        u scene load -n Main
+        u scene load -p Assets/Scenes/UI.unity --additive
+    """
     context: CLIContext = ctx.obj
 
     if not path and not name:
@@ -80,7 +105,15 @@ def scene_save(
     ctx: typer.Context,
     path: Annotated[str | None, typer.Option("--path", "-p", help="Save path")] = None,
 ) -> None:
-    """Save current scene."""
+    """Save the active scene.
+
+    Omit --path to overwrite the current file. Pass --path to save-as to a new
+    asset location (creates a new .unity file).
+
+    Examples:
+        u scene save                                 # Save in place
+        u scene save -p Assets/Scenes/Backup.unity   # Save as copy
+    """
     context: CLIContext = ctx.obj
     result = context.client.scene.save(path=path)
     print_success(result.get("message", "Scene saved"))

--- a/unity_cli/cli/commands/selection.py
+++ b/unity_cli/cli/commands/selection.py
@@ -22,7 +22,12 @@ def register(app: typer.Typer) -> None:
             typer.Option("--json", help="Output as JSON"),
         ] = False,
     ) -> None:
-        """Get current editor selection."""
+        """Return the GameObject(s) currently selected in the Hierarchy/Scene view.
+
+        Reports count, the active selection's name/instance ID/tag/layer/scene path,
+        its Transform (position/rotation/scale), and the full list when multiple
+        objects are selected. Empty output means nothing is selected.
+        """
         context: CLIContext = ctx.obj
         try:
             result = context.client.selection.get()

--- a/unity_cli/cli/commands/tests.py
+++ b/unity_cli/cli/commands/tests.py
@@ -23,7 +23,14 @@ from unity_cli.cli.output import (
 )
 from unity_cli.exceptions import UnityCLIError
 
-tests_app = typer.Typer(help="Test execution commands")
+tests_app = typer.Typer(
+    help=(
+        "Run Unity Test Runner suites (EditMode / PlayMode) from the CLI.\n\n"
+        "Wraps Unity's Test Framework: execute or list tests, filter by assembly,\n"
+        "category, fixture/name regex, and stream live progress. Exit code is non-zero\n"
+        "on test failure so it integrates cleanly with CI."
+    )
+)
 
 
 def _complete_test_mode(incomplete: str) -> list[tuple[str, str]]:
@@ -138,7 +145,19 @@ def tests_run(
         typer.Option("--no-wait", help="Return immediately without waiting for results"),
     ] = False,
 ) -> None:
-    """Run Unity tests."""
+    """Run EditMode or PlayMode tests and wait for results.
+
+    By default runs every test in the chosen mode and polls until completion,
+    printing a live progress summary. Filters are ANDed together.
+
+    Examples:
+        u tests run edit                                  # All EditMode tests
+        u tests run play                                  # All PlayMode tests
+        u tests run edit -a Game.Tests.Editor             # One assembly
+        u tests run edit -g "SceneTest"                   # Regex on test name
+        u tests run edit -n Ns.MyTests.MyCase             # Single test (full name)
+        u tests run edit --no-wait                        # Fire and forget (poll later via 'tests status')
+    """
     context: CLIContext = ctx.obj
     try:
         result = context.client.tests.run(
@@ -178,7 +197,14 @@ def tests_list(
         typer.Option("--json", help="Output as JSON"),
     ] = False,
 ) -> None:
-    """List available tests."""
+    """List every discoverable test name in the given mode.
+
+    Helpful for picking exact values for --test-names or --group-pattern.
+
+    Examples:
+        u tests list edit
+        u tests list play --json
+    """
     context: CLIContext = ctx.obj
     try:
         result = context.client.tests.list(mode=mode)
@@ -207,7 +233,10 @@ def tests_status(
         typer.Option("--json", help="Output as JSON"),
     ] = False,
 ) -> None:
-    """Check running test status."""
+    """Check whether a test run is in progress and its pass/fail counts.
+
+    Pairs with 'u tests run --no-wait' for asynchronous CI-style workflows.
+    """
     context: CLIContext = ctx.obj
     try:
         result = context.client.tests.status()

--- a/unity_cli/cli/commands/uitree.py
+++ b/unity_cli/cli/commands/uitree.py
@@ -21,8 +21,24 @@ from unity_cli.cli.output import (
 )
 from unity_cli.exceptions import UnityCLIError
 
-uitree_app = typer.Typer(help="UI Toolkit tree commands")
-snapshot_app = typer.Typer(help="UI tree snapshot commands")
+uitree_app = typer.Typer(
+    help=(
+        "Inspect and interact with runtime UI Toolkit (UIElements) panels.\n\n"
+        "Targets PanelSettings-backed runtime UI (UIDocument) and editor windows built\n"
+        "on UI Toolkit — not IMGUI. Supports listing panels, dumping the VisualElement\n"
+        "tree, querying by type/name/USS class, inspecting resolved styles, and driving\n"
+        "interactions (click, scroll, get text). Snapshot sub-commands let you diff\n"
+        "trees over time for regression testing, and 'monkey' fuzzes random actions."
+    )
+)
+snapshot_app = typer.Typer(
+    help=(
+        "Save, list, diff, and delete named UI-tree snapshots.\n\n"
+        "A snapshot freezes a panel's VisualElement tree to disk so you can later\n"
+        "compare the current state against it (added/removed/class-changed elements) —\n"
+        "handy for regression tests and visual-review automation."
+    )
+)
 uitree_app.add_typer(snapshot_app, name="snapshot")
 
 


### PR DESCRIPTION
## Summary

- AIエージェントが `u <cmd> --help` のみで適切なコマンドを選べるよう、各サブコマンドのhelp文字列を拡充
- 特に `menu exec` は「MenuItem (built-in/package/custom) を実行できる」という最重要機能が現行helpから読み取れなかったため、3カテゴリの説明+具体例4つを追加
- 動作変更なし (help文字列のみの変更)

## 背景

現状のhelpは `"Menu item commands"` `"Execute a Unity menu item."` のように動詞1行で、ここから「`menu exec` で任意の MenuItem (カスタム `[MenuItem("Tools/...")]` 含む) を呼べる」ことにたどり着けない。同様のdiscoverability問題が他のコマンド群にも存在していたため、一括で改善した。

## 主な変更

### root help
`u --help` の Quick start セクションを追加

```
u instances                            # List connected Unity Editors
u -i <project> state                   # Show editor state
u refresh && u console get -l E        # Recompile then show errors+exceptions
u console get -l W | head -50          # Tail warnings+ (pipe-friendly plain text)
u console clear                        # Wipe the Console
u menu exec 'Window/Package Manager'   # Run any menu item (built-in or custom)
u api schema -t AssetDatabase          # Discover Unity static API methods
```

### group help (用途と使い分けを1-3行で)
`api` / `asset` / `build` / `component` / `config` / `console` / `editor` / `gameobject` / `menu` / `package` / `profiler` / `project` / `recorder` / `scene` / `tests` / `uitree`

例: `menu` group
> Invoke Unity menu items and [ContextMenu] methods.
>
> Covers any MenuItem registered with Unity's menu bar — Unity's built-in menus (Edit/Play, Assets/Refresh, Window/...) AND custom editor tools you or a package register via [MenuItem(\"Tools/MyTool\")]. This is the go-to way to trigger editor workflows that have no dedicated CLI command.

### leaf command help (前提条件+代表例付き)
`menu exec` / `menu context` / `api call` / `api schema` / `scene load/save/hierarchy` / `tests run` / `gameobject create/modify/find/active/delete` / `component add/modify/inspect/list/remove` / `asset prefab/scriptable-object/info/deps/refs` / `build run` / `package add/remove/list` / `profiler start/stop/snapshot/frames` / `recorder start/stop/status` / `editor install/list` / `state/play/stop/pause/refresh` / `selection` / `console get/clear` / `config show/init`

## Test plan

- [x] \`uv run python -m pytest tests/ --ignore=tests/integration\` 550 passed / 2 skipped
- [x] \`uv run ruff check unity_cli/cli/\` pass
- [x] pre-commit hooks (ruff/mypy/xenon/import-linter) pass
- [x] \`uv tool install . --reinstall\` 後、\`u --help\` / \`u menu --help\` / \`u menu exec --help\` で新テキスト表示を目視確認

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## ドキュメント

* CLIコマンド全体のヘルプテキストと説明文を大幅に改善しました。複数のコマンドグループ（App、API、Asset、Build、Component など）において、より詳しい説明と実行例が追加されました。これにより、ユーザーは各機能の使い方をより正確に理解し、効果的に活用できるようになります。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->