### PR TITLE
feat: support asset path for ObjectReference & parent option for GameObject create

### DIFF
--- a/UnityBridge/Editor/Tools/Component.cs
+++ b/UnityBridge/Editor/Tools/Component.cs
@@ -348,11 +348,29 @@ namespace UnityBridge.Tools
                         var obj = EditorUtility.InstanceIDToObject(value.Value<int>());
                         sp.objectReferenceValue = obj;
                     }
+                    else if (value.Type == JTokenType.String)
+                    {
+                        var path = value.Value<string>();
+                        UnityEngine.Object obj = AssetDatabase.LoadMainAssetAtPath(path);
+                        if (obj == null)
+                        {
+                            throw new ProtocolException(
+                                ErrorCode.InvalidParams,
+                                $"Asset not found at path: {path}");
+                        }
+                        if (obj is Texture2D)
+                        {
+                            var sprite = AssetDatabase.LoadAllAssetsAtPath(path)
+                                .OfType<Sprite>().FirstOrDefault();
+                            if (sprite != null) obj = sprite;
+                        }
+                        sp.objectReferenceValue = obj;
+                    }
                     else
                     {
                         throw new ProtocolException(
                             ErrorCode.InvalidParams,
-                            "ObjectReference value must be null, empty string, or instanceID (integer)");
+                            "ObjectReference value must be null, empty string, instanceID (integer), or asset path (string)");
                     }
                     break;
                 default:

--- a/UnityBridge/Editor/Tools/GameObject.cs
+++ b/UnityBridge/Editor/Tools/GameObject.cs
@@ -111,6 +111,24 @@ namespace UnityBridge.Tools
 
             Undo.RegisterCreatedObjectUndo(newGo, $"Create GameObject '{name}'");
 
+            // Set parent if specified
+            var parentName = parameters["parent"]?.Value<string>();
+            var parentId = parameters["parentId"]?.Value<int>();
+            if (!string.IsNullOrEmpty(parentName) || parentId.HasValue)
+            {
+                var parentGo = GameObjectFinder.Find(parentName, parentId);
+                if (parentGo == null)
+                {
+                    // Clean up the created object before throwing
+                    Undo.DestroyObjectImmediate(newGo);
+                    var reference = !string.IsNullOrEmpty(parentName) ? parentName : parentId!.Value.ToString();
+                    throw new ProtocolException(
+                        ErrorCode.InvalidParams,
+                        $"Parent GameObject not found: '{reference}'");
+                }
+                newGo.transform.SetParent(parentGo.transform, worldPositionStays: false);
+            }
+
             // Apply transform
             ApplyTransform(newGo.transform, parameters);
 

--- a/unity_cli/api/gameobject.py
+++ b/unity_cli/api/gameobject.py
@@ -39,6 +39,8 @@ class GameObjectAPI:
         self,
         name: str,
         primitive_type: str | None = None,
+        parent: str | None = None,
+        parent_id: int | None = None,
         position: list[float] | None = None,
         rotation: list[float] | None = None,
         scale: list[float] | None = None,
@@ -48,6 +50,8 @@ class GameObjectAPI:
         Args:
             name: Name for the new GameObject
             primitive_type: Primitive type (e.g., "Cube", "Sphere")
+            parent: Parent GameObject name
+            parent_id: Parent GameObject instance ID
             position: Initial position [x, y, z]
             rotation: Initial rotation [x, y, z]
             scale: Initial scale [x, y, z]
@@ -58,6 +62,10 @@ class GameObjectAPI:
         params: dict[str, Any] = {"action": "create", "name": name}
         if primitive_type:
             params["primitive"] = primitive_type
+        if parent:
+            params["parent"] = parent
+        if parent_id is not None:
+            params["parentId"] = parent_id
         if position:
             params["position"] = position
         if rotation:

--- a/unity_cli/cli/commands/gameobject.py
+++ b/unity_cli/cli/commands/gameobject.py
@@ -75,6 +75,14 @@ def gameobject_create(
             help="Primitive type: Cube, Sphere, Capsule, Cylinder, Plane, Quad (omit for empty GameObject)",
         ),
     ] = None,
+    parent: Annotated[
+        str | None,
+        typer.Option("--parent", help="Parent GameObject name"),
+    ] = None,
+    parent_id: Annotated[
+        int | None,
+        typer.Option("--parent-id", help="Parent GameObject instance ID"),
+    ] = None,
     position: Annotated[
         tuple[float, float, float] | None,
         typer.Option("--position", help="Position (X Y Z)"),
@@ -104,6 +112,8 @@ def gameobject_create(
     result = context.client.gameobject.create(
         name=name,
         primitive_type=primitive,
+        parent=parent,
+        parent_id=parent_id,
         position=list(position) if position else None,
         rotation=list(rotation) if rotation else None,
         scale=list(scale) if scale else None,


### PR DESCRIPTION
## Summary

Two enhancements for AI-driven Unity workflows:

### 1. Asset path support for ObjectReference

Previously, assigning a sprite to an Image required manually looking up the asset's GUID and fileID from `.meta` files. Now you can pass the asset path directly:

```bash
u component modify -t "MyImage" -T "Image" -p "m_Sprite" -v "Assets/Sprites/icon.png"
```

- Resolves paths via AssetDatabase.LoadMainAssetAtPath
- Automatically extracts Sprite sub-asset from Texture2D (handles both spriteMode Single
and Multiple)
- Existing behaviors (null, empty string, instanceID) unchanged

### 2. Parent option for gameobject create
```bash
u gameobject create "ChildObject" --parent "Canvas/Panel"
```

- New --parent (by name) and --parent-id (by instance ID) options
- Sets parent before applying transform, so position/rotation/scale are in local space
- Cleans up created object if parent not found (no orphans)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * GameObjectの作成時に親オブジェクトの指定が可能になりました
  * アセットパスから資産を読み込み、Texture2DをSpriteに自動変換する機能を追加しました

* **改善**
  * ObjectReference入力の検証エラーメッセージを更新し、サポートされている入力形式を明確化しました

<!-- end of auto-generated comment: release notes by coderabbit.ai -->