### PR TITLE
🔥 remove: drop `unity` command alias

### DIFF
--- a/README.jp.md
+++ b/README.jp.md
@@ -97,10 +97,9 @@ uv tool install git+https://github.com/bigdra50/unity-cli
 # インタラクティブUI付き（エディタ選択プロンプト）
 uv tool install "git+https://github.com/bigdra50/unity-cli[interactive]"
 
-# CLIコマンド（すべてのエイリアスが同じ動作）
+# CLIコマンド（どちらのエイリアスも同じ動作）
 unity-cli state    # フルネーム
-unity state        # 短縮形
-u state            # 最短形
+u state            # 短縮形
 
 u play
 u console get -l E | head -10  # 最新10件のエラー以上

--- a/README.md
+++ b/README.md
@@ -97,10 +97,9 @@ uv tool install git+https://github.com/bigdra50/unity-cli
 # With interactive UI (editor selection prompt)
 uv tool install "git+https://github.com/bigdra50/unity-cli[interactive]"
 
-# CLI commands (all aliases work the same)
+# CLI commands (both aliases work the same)
 unity-cli state    # Full name
-unity state        # Short alias
-u state            # Shortest alias
+u state            # Short alias
 
 u play
 u console get -l E | head -10  # Last 10 error+ logs

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,7 +54,6 @@ Repository = "https://github.com/bigdra50/unity-cli"
 
 [project.scripts]
 unity-cli = "unity_cli:main"
-unity = "unity_cli:main"
 u = "unity_cli:main"
 unity-relay = "relay.server:main"
 


### PR DESCRIPTION
Closes #119

## Summary

- Remove `unity` entrypoint from `[project.scripts]` because it collides with the official Unity Hub CLI on `PATH`
- Keep `unity-cli` (canonical) and `u` (short alias)
- Update README examples (EN/JP) to drop the `unity state` line

## Breaking change

Scripts invoking `unity ...` must switch to `u ...` or `unity-cli ...`. Worth highlighting in the next release notes.

## Test plan

- [ ] `uv tool install .` and confirm only `unity-cli` / `u` / `unity-relay` are exposed (no `unity`)
- [ ] `u state` / `unity-cli state` still work
- [ ] On a machine with Unity Hub installed, `which unity` resolves to the official Unity Hub CLI (no shadowing)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **ドキュメント**
  * CLIコマンドの使用例を更新し、`state` コマンドの実行方法を `unity-cli state`（フルネーム）と `u state`（短縮形）に整理しました。従来の別の実行方法は削除されました。

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/bigdra50/unity-cli/pull/120)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->